### PR TITLE
append result in DNS fail case and move to next entry

### DIFF
--- a/checks/http.go
+++ b/checks/http.go
@@ -89,12 +89,14 @@ func (c *HttpChecker) Check(check pkg.HTTPCheck) []*pkg.CheckResult {
 		if err != nil {
 			log.Printf("Failed to resolve DNS for %s", endpoint)
 			dnsFailed.Inc()
-			return []*pkg.CheckResult{{
+			checkResult := &pkg.CheckResult{
 				Pass:     false,
 				Invalid:  true,
 				Endpoint: endpoint,
 				Metrics:  []pkg.Metric{},
-			}}
+			}
+			result = append(result, checkResult)
+			continue
 		}
 		for _, urlObj := range lookupResult {
 			checkResults, err := c.checkHTTP(urlObj)

--- a/fixtures/http_fail.yaml
+++ b/fixtures/http_fail.yaml
@@ -1,5 +1,6 @@
 http:
   - endpoints:
+      - https://ttpstat.us/500
       - https://httpstat.us/500
     thresholdMillis: 3000
     responseCodes: [201,200,301]


### PR DESCRIPTION
appending result in DNS fail cases and move to next entry. Test case added in http_fail.yaml file.