### PR TITLE
Prevent multiple overlapping popovers for graph

### DIFF
--- a/statuspage/src/components/BarPopover.vue
+++ b/statuspage/src/components/BarPopover.vue
@@ -5,7 +5,7 @@
             :target="target"
             triggers="hover"
             placement="top"
-            :delay="{ show: 50, hide: 350 }"
+            :delay="{ show: 100, hide: 100 }"
             @show="onShow">
         <template v-slot:title>
             <div class="description">{{description}}</div><div>{{elapsed}}</div>

--- a/statuspage/vue.config.js
+++ b/statuspage/vue.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     devServer: {
-        port: 8081,
+        port: 8085,
         proxy: {
             '^/api': {
                 target: 'http://localhost:8080/',


### PR DESCRIPTION
closes https://github.com/flanksource/canary-checker/issues/96

The answer was a lot less "industrial" than I initially imagined:
as long as _the show delay_ >= _the hide delay_ the page won't display two popovers at the same time.

The previous settings of waiting 50ms to show a popover when hovering and waiting 350ms to hide it after moving off it was a recipe for multiple displayed at the same time.