### PR TITLE
Switch from ESC to go embed

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -7,7 +7,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     container:
-      image: flanksource/build-tools:0.6
+      image: flanksource/build-tools:v0.12.0
     steps:
       - uses: actions/checkout@master
       - run: ./release.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     container:
-      image: flanksource/build-tools
+      image: flanksource/build-tools:v0.12.0
     steps:
       - uses: actions/checkout@master
       - run: make static build-api-docs build-docs deploy-docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13.x]
+        go-version: [1.16.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 build/
 docs/cli/
 .DS_Store
-statuspage/static.go
 cover.out
 test.test
 *.tgz

--- a/Makefile
+++ b/Makefile
@@ -94,11 +94,11 @@ compress:
 
 
 .PHONY: linux
-linux: static
+linux: vue-dist
 	GOOS=linux go build -o ./.bin/$(NAME) -ldflags "-X \"main.version=$(VERSION)\""  main.go
 
 .PHONY: darwin
-darwin: static
+darwin: vue-dist
 	GOOS=darwin go build -o ./.bin/$(NAME)_osx -ldflags "-X \"main.version=$(VERSION)\""  main.go
 
 .PHONY: serve-docs
@@ -124,11 +124,6 @@ deploy-docs:
 .PHONY: vue-dist
 vue-dist:
 	cd statuspage && npm install && npm run build
-
-.PHONY: static
-static: vue-dist
-	which esc 2>&1 > /dev/null || go get -u github.com/mjibson/esc
-	cd statuspage/dist && esc -o ../static.go -pkg statuspage .
 
 .PHONY: build
 build:

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -77,7 +77,7 @@ func serve(cmd *cobra.Command) {
 		logger.Infof("    npm run serve -- --port %d ", devGuiHttpPort)
 		logger.Infof("   )")
 	} else {
-		staticRoot = statuspage.FS(false)
+		staticRoot = nethttp.FS(statuspage.StaticContent)
 		allowedCors = ""
 	}
 

--- a/fixtures/postgres_succeed.yaml
+++ b/fixtures/postgres_succeed.yaml
@@ -2,3 +2,4 @@ postgres:
   - connection: "postgres://postgresadmin:admin123@127.0.0.1:32432/postgres?sslmode=disable"
     query: "SELECT 1"
     results: 1
+    driver: postgres

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flanksource/canary-checker
 
-go 1.13
+go 1.16
 
 require (
 	github.com/asecurityteam/rolling v2.0.4+incompatible

--- a/statuspage/static.go
+++ b/statuspage/static.go
@@ -1,0 +1,8 @@
+package statuspage
+
+import "embed"
+
+//nolint
+//go:embed dist/*
+var StaticContent embed.FS
+

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -51,3 +51,8 @@ ca:
   cert: .certs/root-ca.crt
   privateKey: .certs/root-ca.key
   password: foobar
+minio:
+  version: RELEASE.2020-09-02T18-19-50Z
+  access_key: minio
+  secret_key: minio123
+  replicas: 1

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-export PLATFORM_CLI_VERSION=v0.17.9
-export PLATFORM_CLI="./platform-cli -c test/config.yaml"
+export PLATFORM_CLI_VERSION=v0.28.0
+export PLATFORM_CLI="./karina -c test/config.yaml"
 export KUBECONFIG=~/.kube/config
 export DOCKER_API_VERSION=1.39
 
@@ -12,12 +12,12 @@ if which karina 2>&1 > /dev/null; then
   PLATFORM_CLI="karina -c test/config.yaml"
 else
   if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    wget -q https://github.com/flanksource/platform-cli/releases/download/$PLATFORM_CLI_VERSION/platform-cli
-    chmod +x platform-cli
+    wget -q https://github.com/flanksource/karina/releases/download/$PLATFORM_CLI_VERSION/karina
+    chmod +x karina
   elif [[ "$OSTYPE" == "darwin"* ]]; then
-    wget -q https://github.com/flanksource/platform-cli/releases/download/$PLATFORM_CLI_VERSION/platform-cli_osx
-    cp platform-cli_osx platform-cli
-    chmod +x platform-cli
+    wget -q https://github.com/flanksource/karina/releases/download/$PLATFORM_CLI_VERSION/karina_osx
+    cp karina_osx karina
+    chmod +x karina
   else
     echo "OS $OSTYPE not supported"
     exit 1
@@ -31,8 +31,8 @@ $PLATFORM_CLI ca generate --name ingress-ca --cert-path .certs/ingress-ca.crt --
 $PLATFORM_CLI provision kind-cluster
 
 
-$PLATFORM_CLI deploy phases --base --stubs --calico
-$PLATFORM_CLI test stubs --wait=480
+$PLATFORM_CLI deploy phases --crds --base --stubs --calico --minio
+#$PLATFORM_CLI test stubs --wait=480 -v 5
 $PLATFORM_CLI apply test/setup.yml
 
 export DOCKER_USERNAME=test
@@ -45,7 +45,7 @@ chmod +x ./wait4x
 ./wait4x tcp 127.0.0.1:30389 || true
 ./wait4x tcp 127.0.0.1:32432 || true
 
-make static
+make vue-dist
 cd test
 go test ./... -v -c
 # ICMP requires privelages so we run the tests with sudo


### PR DESCRIPTION
Fixes #128 
Fixes #125 

Updated build chain to go1.16 based images
Included static content using go embed instead of esc
removed 'pack' make target
Updated karina version used in testing