### PR TITLE
feat: Add popup on a canary with its details

### DIFF
--- a/api/v1/canary_types.go
+++ b/api/v1/canary_types.go
@@ -43,6 +43,8 @@ type CanarySpec struct {
 	Namespace      []NamespaceCheck      `yaml:"namespace,omitempty" json:"namespace,omitempty"`
 	Redis          []RedisCheck          `yaml:"redis,omitempty" json:"redis,omitempty"`
 	Interval       uint64                `yaml:"interval,omitempty" json:"interval,omitempty"`
+	Severity       string                `yaml:"severity,omitempty" json:"severity,omitempty"`
+	Owner          string                `yaml:"owner,omitempty" json:"owner,omitempty"`
 }
 
 func (spec CanarySpec) GetAllChecks() []external.Check {

--- a/config/crd.yaml
+++ b/config/crd.yaml
@@ -499,6 +499,8 @@ spec:
                       type: integer
                   type: object
                 type: array
+              owner:
+                type: string
               pod:
                 items:
                   properties:
@@ -646,6 +648,8 @@ spec:
                       type: boolean
                   type: object
                 type: array
+              severity:
+                type: string
               tcp:
                 items:
                   properties:

--- a/pkg/aggregate/aggregate.go
+++ b/pkg/aggregate/aggregate.go
@@ -30,6 +30,9 @@ type AggregateCheck struct {
 	Endpoint    string                       `json:"endpoint"`
 	Health      map[string]CheckHealth       `json:"health"`
 	Statuses    map[string][]pkg.CheckStatus `json:"checkStatuses"`
+	Interval    uint64                       `json:"interval"`
+	Owner       string                       `json:"owner"`
+	Severity    string                       `json:"severity"`
 }
 
 type CheckHealth struct {
@@ -94,6 +97,9 @@ func Handler(w nethttp.ResponseWriter, req *nethttp.Request) {
 			Type:        c.Type,
 			Description: c.Description,
 			Endpoint:    c.Endpoint,
+			Interval:    c.Interval,
+			Owner:       c.Owner,
+			Severity:    c.Severity,
 			ServerURL:   "local",
 			Health: map[string]CheckHealth{
 				localServerId: {c.Latency, c.Uptime},
@@ -129,6 +135,9 @@ func Handler(w nethttp.ResponseWriter, req *nethttp.Request) {
 					Type:        c.Type,
 					Description: c.Description,
 					Endpoint:    c.Endpoint,
+					Interval:    c.Interval,
+					Owner:       c.Owner,
+					Severity:    c.Severity,
 					ServerURL:   serverURL,
 					Health: map[string]CheckHealth{
 						serverId: {c.Latency, c.Uptime},

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -52,6 +52,9 @@ type Check struct {
 	Uptime      string        `json:"uptime"`
 	Latency     string        `json:"latency"`
 	Statuses    []CheckStatus `json:"checkStatuses" mapstructure:"-"`
+	Interval    uint64        `json:"interval"`
+	Owner       string        `json:"owner"`
+	Severity    string        `json:"severity"`
 	CheckCanary *v1.Canary    `json:"-"`
 }
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -65,6 +65,9 @@ func (c *cache) InitCheck(checks v1.Canary) {
 			CanaryName:  checks.Name,
 			Description: check.GetDescription(),
 			Endpoint:    check.GetEndpoint(),
+			Interval:    checks.Spec.Interval,
+			Owner:       checks.Spec.Owner,
+			Severity:    checks.Spec.Severity,
 		}
 		c.CheckConfigs[key] = check
 	}
@@ -86,6 +89,9 @@ func (c *cache) AddCheck(checks v1.Canary, result *pkg.CheckResult) *pkg.Check {
 		CanaryName:  checks.Name,
 		Description: checks.GetDescription(result.Check),
 		Endpoint:    result.Check.GetEndpoint(),
+		Interval:    checks.Spec.Interval,
+		Owner:       checks.Spec.Owner,
+		Severity:    checks.Spec.Severity,
 		CheckCanary: &checks,
 		Statuses: []pkg.CheckStatus{
 			{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -23,7 +23,7 @@ var (
 			Name: "canary_check_count",
 			Help: "The total number of checks",
 		},
-		[]string{"type", "endpoint", "name", "namespace"},
+		[]string{"type", "endpoint", "name", "namespace", "owner", "severity"},
 	)
 
 	OpsSuccessCount = prometheus.NewCounterVec(
@@ -31,7 +31,7 @@ var (
 			Name: "canary_check_success_count",
 			Help: "The total number of successful checks",
 		},
-		[]string{"type", "endpoint", "name", "namespace"},
+		[]string{"type", "endpoint", "name", "namespace", "owner", "severity"},
 	)
 
 	OpsFailedCount = prometheus.NewCounterVec(
@@ -39,7 +39,7 @@ var (
 			Name: "canary_check_failed_count",
 			Help: "The total number of failed checks",
 		},
-		[]string{"type", "endpoint", "name", "namespace"},
+		[]string{"type", "endpoint", "name", "namespace", "owner", "severity"},
 	)
 
 	RequestLatency = prometheus.NewHistogramVec(
@@ -48,7 +48,7 @@ var (
 			Help:    "A histogram of the response latency in milliseconds.",
 			Buckets: []float64{5, 10, 25, 50, 200, 500, 1000, 3000, 10000, 30000},
 		},
-		[]string{"type", "endpoint", "name", "namespace"},
+		[]string{"type", "endpoint", "name", "namespace", "owner", "severity"},
 	)
 
 	Guage = prometheus.NewGaugeVec(
@@ -56,7 +56,7 @@ var (
 			Name: "canary_check",
 			Help: "A gauge representing the canaries success (0) or failure (1)",
 		},
-		[]string{"type", "endpoint", "name", "namespace"},
+		[]string{"type", "endpoint", "name", "namespace", "owner", "severity"},
 	)
 
 	GenericGauge = prometheus.NewGaugeVec(
@@ -64,7 +64,7 @@ var (
 			Name: "canary_check_gauge",
 			Help: "A gauge representing duration",
 		},
-		[]string{"type", "name", "metric", "namespace"},
+		[]string{"type", "name", "metric", "namespace", "owner", "severity"},
 	)
 
 	GenericCounter = prometheus.NewCounterVec(
@@ -72,7 +72,7 @@ var (
 			Name: "canary_check_counter",
 			Help: "A gauge representing counters",
 		},
-		[]string{"type", "name", "metric", "value", "namespace"},
+		[]string{"type", "name", "metric", "value", "namespace", "owner", "severity"},
 	)
 
 	GenericHistogram = prometheus.NewHistogramVec(
@@ -81,7 +81,7 @@ var (
 			Help:    "A histogram representing durations",
 			Buckets: []float64{5, 10, 25, 50, 200, 500, 1000, 2500, 5000, 10000, 20000},
 		},
-		[]string{"type", "name", "metric", "namespace"},
+		[]string{"type", "name", "metric", "namespace", "owner", "severity"},
 	)
 )
 
@@ -130,6 +130,8 @@ func Record(check v1.Canary, result *pkg.CheckResult) (rollingUptime string, rol
 	name := check.Name
 	checkType := result.Check.GetType()
 	endpoint := check.GetDescription(result.Check)
+	owner    := check.Spec.Owner
+	severity := check.Spec.Severity
 	// We are recording aggreated metrics at the canary level, not the individual check level
 	key := check.GetKey(result.Check)
 
@@ -154,32 +156,32 @@ func Record(check v1.Canary, result *pkg.CheckResult) (rollingUptime string, rol
 	if logger.IsTraceEnabled() {
 		logger.Tracef(result.String())
 	}
-	OpsCount.WithLabelValues(checkType, endpoint, name, namespace).Inc()
+	OpsCount.WithLabelValues(checkType, endpoint, name, namespace, owner, severity).Inc()
 	if result.Duration > 0 {
-		RequestLatency.WithLabelValues(checkType, endpoint, name, namespace).Observe(float64(result.Duration))
+		RequestLatency.WithLabelValues(checkType, endpoint, name, namespace, owner, severity).Observe(float64(result.Duration))
 		latency.Append(float64(result.Duration))
 	}
 	if result.Pass {
 		pass.Append(1)
-		Guage.WithLabelValues(checkType, endpoint, name, namespace).Set(0)
-		OpsSuccessCount.WithLabelValues(checkType, endpoint, name, namespace).Inc()
+		Guage.WithLabelValues(checkType, endpoint, name, namespace, owner, severity).Set(0)
+		OpsSuccessCount.WithLabelValues(checkType, endpoint, name, namespace, owner, severity).Inc()
 		// always add a failed count to ensure the metric is present in prometheus
 		// for an uptime calculation
-		OpsFailedCount.WithLabelValues(checkType, endpoint, name, namespace).Add(0)
+		OpsFailedCount.WithLabelValues(checkType, endpoint, name, namespace, owner, severity).Add(0)
 		for _, m := range result.Metrics {
 			switch m.Type {
 			case CounterType:
-				GenericCounter.WithLabelValues(checkType, endpoint, m.Name, strconv.Itoa(int(m.Value)), namespace).Inc()
+				GenericCounter.WithLabelValues(checkType, endpoint, m.Name, strconv.Itoa(int(m.Value)), namespace, owner, severity).Inc()
 			case GaugeType:
-				GenericGauge.WithLabelValues(checkType, endpoint, m.Name, namespace).Set(m.Value)
+				GenericGauge.WithLabelValues(checkType, endpoint, m.Name, namespace, owner, severity).Set(m.Value)
 			case HistogramType:
-				GenericHistogram.WithLabelValues(checkType, endpoint, m.Name, namespace).Observe(m.Value)
+				GenericHistogram.WithLabelValues(checkType, endpoint, m.Name, namespace, owner, severity).Observe(m.Value)
 			}
 		}
 	} else {
 		fail.Append(1)
-		Guage.WithLabelValues(checkType, endpoint, name, namespace).Set(1)
-		OpsFailedCount.WithLabelValues(checkType, endpoint, name, namespace).Inc()
+		Guage.WithLabelValues(checkType, endpoint, name, namespace, owner, severity).Set(1)
+		OpsFailedCount.WithLabelValues(checkType, endpoint, name, namespace, owner, severity).Inc()
 	}
 	failCount := fail.Reduce(rolling.Sum)
 	passCount := pass.Reduce(rolling.Sum)

--- a/statuspage/package-lock.json
+++ b/statuspage/package-lock.json
@@ -1746,6 +1746,16 @@
           "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
           "dev": true
         },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
         "cacache": {
           "version": "13.0.1",
           "resolved": "https://registry.npm.taobao.org/cacache/download/cacache-13.0.1.tgz?cache=0&sync_timestamp=1594429684526&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcacache%2Fdownload%2Fcacache-13.0.1.tgz",
@@ -1772,6 +1782,34 @@
             "unique-filename": "^1.1.1"
           }
         },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
         "find-cache-dir": {
           "version": "3.3.1",
           "resolved": "https://registry.npm.taobao.org/find-cache-dir/download/find-cache-dir-3.3.1.tgz",
@@ -1791,6 +1829,25 @@
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
           }
         },
         "locate-path": {
@@ -1857,6 +1914,16 @@
             "minipass": "^3.1.1"
           }
         },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
         "terser-webpack-plugin": {
           "version": "2.3.8",
           "resolved": "https://registry.npm.taobao.org/terser-webpack-plugin/download/terser-webpack-plugin-2.3.8.tgz?cache=0&sync_timestamp=1602083079523&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fterser-webpack-plugin%2Fdownload%2Fterser-webpack-plugin-2.3.8.tgz",
@@ -1872,6 +1939,18 @@
             "source-map": "^0.6.1",
             "terser": "^4.6.12",
             "webpack-sources": "^1.4.3"
+          }
+        },
+        "vue-loader-v16": {
+          "version": "npm:vue-loader@16.2.0",
+          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.2.0.tgz",
+          "integrity": "sha512-TitGhqSQ61RJljMmhIGvfWzJ2zk9m1Qug049Ugml6QP3t0e95o0XJjk29roNEiPKJQBEi8Ord5hFuSuELzSp8Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "hash-sum": "^2.0.0",
+            "loader-utils": "^2.0.0"
           }
         }
       }
@@ -11168,87 +11247,6 @@
           "resolved": "https://registry.npm.taobao.org/hash-sum/download/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
-        }
-      }
-    },
-    "vue-loader-v16": {
-      "version": "npm:vue-loader@16.2.0",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.2.0.tgz",
-      "integrity": "sha512-TitGhqSQ61RJljMmhIGvfWzJ2zk9m1Qug049Ugml6QP3t0e95o0XJjk29roNEiPKJQBEi8Ord5hFuSuELzSp8Q==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "chalk": "^4.1.0",
-        "hash-sum": "^2.0.0",
-        "loader-utils": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },

--- a/statuspage/src/App.vue
+++ b/statuspage/src/App.vue
@@ -21,7 +21,7 @@
                 </tr>
 
                 <template v-for="(check) in byNamespace.items" >
-                      <table-row :interval="check.interval"
+                      <canary-standard-server-row :interval="check.interval"
                                  :owner="check.owner"
                                  :severity="check.severity"
                                  :check-type="check.type"
@@ -54,12 +54,12 @@ import Vuex from "vuex";
 import store from "./store";
 import AutoUpdateSettings from "./components/AutoUpdateSettings.vue";
 import ErrorPanel from "./components/ErrorPanel.vue";
-import TableRow from "@/components/TableRow";
+import CanaryStandardServerRow from "./components/CanaryStandardServerRow.vue";
 
 export default {
   name: "App",
   components: {
-    TableRow,
+    CanaryStandardServerRow,
     AutoUpdateSettings,
     ErrorPanel,
   },

--- a/statuspage/src/App.vue
+++ b/statuspage/src/App.vue
@@ -22,8 +22,9 @@
 
                 <template v-for="(check) in byNamespace.items" >
                     <tr :key="checkKey(check)" >
-                        <td v-b-modal="'modal-canary'+check.name+check.namespace">
-                                <img :src="'images/' + check.type + '.svg'" :title="check.type " height="20px" >  {{ shortHand(checkName(check),60) }}
+<!--                      Component modal doc: : https://bootstrap-vue.org/docs/components/modal-->
+                      <td v-b-modal="`modal-canary${check.name}${check.namespace}`">
+                                <img :src="`images/${check.type}.svg`" :title="check.type " v-bind:style="{ height: '1.25rem' }" alt="" >  {{ shortHand(checkName(check),60) }}
                               <canary-modal :interval="check.interval"
                                             :owner="check.owner"
                                             :severity="check.severity"
@@ -115,8 +116,7 @@ export default {
 
     checkKey() {
       return (check) => {
-        let id = check.key + check.id + check.description + check.name + check.namespace + check.endpoint + check.serverURL
-        return id
+        return `${check.key}${check.id}${check.description}${check.name}${check.namespace}${check.endpoint}${check.serverURL}`
       }
     },
 

--- a/statuspage/src/App.vue
+++ b/statuspage/src/App.vue
@@ -21,29 +21,17 @@
                 </tr>
 
                 <template v-for="(check) in byNamespace.items" >
-                    <tr :key="checkKey(check)" >
-<!--                      Component modal doc: : https://bootstrap-vue.org/docs/components/modal-->
-                      <td v-b-modal="`modal-canary${check.name}${check.namespace}`">
-                                <img :src="`images/${check.type}.svg`" :title="check.type " v-bind:style="{ height: '1.25rem' }" alt="" >  {{ shortHand(checkName(check),60) }}
-                              <canary-modal :interval="check.interval"
-                                            :owner="check.owner"
-                                            :severity="check.severity"
-                                            :check-type="check.type"
-                                            :description="check.description"
-                                            :name="check.name"
-                                            :namespace="check.namespace"
-                              />
-                        </td>
-
-                        <td v-for="server in orderedServers" :key="server.value" class="align-top border-right border-left">
-                            <div>
-                              <status-strip  :checks="check.items" :server="server.value"
-                                          color="#28a745" error-color="#dc3545"
-                                           :bar-width="20" :bar-spacing="5" :barMaxHeight="20"
-                                           :zoominess="0.85"/>
-                            </div>
-                        </td>
-                    </tr>
+                      <table-row :interval="check.interval"
+                                 :owner="check.owner"
+                                 :severity="check.severity"
+                                 :check-type="check.type"
+                                 :description="check.description"
+                                 :name="check.name"
+                                 :namespace="check.namespace"
+                                 :short-description="shortHand(checkName(check),60)"
+                                 :items="check.items"
+                                 :key="checkKey(check)"
+                                 />
                 </template>
 
             </template>
@@ -66,16 +54,14 @@ import Vuex from "vuex";
 import store from "./store";
 import AutoUpdateSettings from "./components/AutoUpdateSettings.vue";
 import ErrorPanel from "./components/ErrorPanel.vue";
-import StatusStrip from "./components/StatusStrip.vue";
-import CanaryModal from "@/components/CanaryModal";
+import TableRow from "@/components/TableRow";
 
 export default {
   name: "App",
   components: {
-    CanaryModal,
+    TableRow,
     AutoUpdateSettings,
     ErrorPanel,
-    StatusStrip,
   },
   store: store,
   created() {

--- a/statuspage/src/App.vue
+++ b/statuspage/src/App.vue
@@ -22,8 +22,16 @@
 
                 <template v-for="(check) in byNamespace.items" >
                     <tr :key="checkKey(check)" >
-                        <td>
-                                <img :src="'images/' + check.type + '.svg'" :title="check.type " height="20px">  {{ shortHand(checkName(check),60) }}
+                        <td v-b-modal="'modal-canary'+check.name+check.namespace">
+                                <img :src="'images/' + check.type + '.svg'" :title="check.type " height="20px" >  {{ shortHand(checkName(check),60) }}
+                              <canary-modal :interval="check.interval"
+                                            :owner="check.owner"
+                                            :severity="check.severity"
+                                            :check-type="check.type"
+                                            :description="check.description"
+                                            :name="check.name"
+                                            :namespace="check.namespace"
+                              />
                         </td>
 
                         <td v-for="server in orderedServers" :key="server.value" class="align-top border-right border-left">
@@ -58,10 +66,12 @@ import store from "./store";
 import AutoUpdateSettings from "./components/AutoUpdateSettings.vue";
 import ErrorPanel from "./components/ErrorPanel.vue";
 import StatusStrip from "./components/StatusStrip.vue";
+import CanaryModal from "@/components/CanaryModal";
 
 export default {
   name: "App",
   components: {
+    CanaryModal,
     AutoUpdateSettings,
     ErrorPanel,
     StatusStrip,
@@ -105,7 +115,7 @@ export default {
 
     checkKey() {
       return (check) => {
-        let id = check.key + check.id + check.description + check.name + check.namespace + check.endpoint + check.ServerURL
+        let id = check.key + check.id + check.description + check.name + check.namespace + check.endpoint + check.serverURL
         return id
       }
     },

--- a/statuspage/src/components/CanaryModal.vue
+++ b/statuspage/src/components/CanaryModal.vue
@@ -1,18 +1,20 @@
 <!-- This component encapsulates a modal that is displayed -->
 <!-- when clicking on canary                               -->
 <template>
-  <b-modal :id="'modal-canary'+name+namespace" ok-only>
+<!--  Here we use dynamic id for the modal since it is being called from a loop.-->
+<!--  If ID is not distinguished then a click on any row will open modal for every value-->
+  <b-modal :id="`modal-canary${name}${namespace}`" ok-only>
     <template #modal-title>
-      <img :src="'images/' + checkType + '.svg'" height="30px"> {{name}}
+      <img :src="`images/${checkType}.svg`" v-bind:style="{ height: '1.875rem' }" alt=""> {{name}}
     </template>
-    <template v-slot:default>
-      <div class="name"><b>Name:</b> {{name}}</div>
-      <div class="namespace"><b>Namespace:</b> {{namespace}}</div>
-      <div class="description"><b>Description:</b> {{description}}</div>
-      <div class="interval"><b>Interval:</b> {{interval}} Seconds</div>
-      <div class="owner" v-if="owner.length !== 0"><b>Owner:</b> {{owner}}</div>
-      <div class="severity" v-if="severity.length !== 0"><b>Severity:</b> {{severity}}</div>
-    </template>
+    <ul class="list-unstyled">
+      <li><b>Name:</b> {{name}}</li>
+      <li><b>Namespace:</b> {{namespace}}</li>
+      <li><b>Description:</b> {{description}}</li>
+      <li><b>Interval:</b> {{interval}} Seconds</li>
+      <li><b>Owner:</b> {{getProp(owner)}}</li>
+      <li><b>Severity:</b> {{getProp(severity)}}</li>
+    </ul>
   </b-modal>
 
 </template>
@@ -52,9 +54,21 @@ export default {
       required: true,
     },
   },
+  methods: {
+    getProp(prop){
+      if (prop.length === 0) {
+        return "-"
+      }
+      return prop
+    }
+  }
 }
 </script>
 
 <style scoped>
-
+.list-unstyled {
+  list-style: none;
+  margin-left: 0;
+  padding-left: 0;
+}
 </style>

--- a/statuspage/src/components/CanaryModal.vue
+++ b/statuspage/src/components/CanaryModal.vue
@@ -1,0 +1,60 @@
+<!-- This component encapsulates a modal that is displayed -->
+<!-- when clicking on canary                               -->
+<template>
+  <b-modal :id="'modal-canary'+name+namespace" ok-only>
+    <template #modal-title>
+      <img :src="'images/' + checkType + '.svg'" height="30px"> {{name}}
+    </template>
+    <template v-slot:default>
+      <div class="name"><b>Name:</b> {{name}}</div>
+      <div class="namespace"><b>Namespace:</b> {{namespace}}</div>
+      <div class="description"><b>Description:</b> {{description}}</div>
+      <div class="interval"><b>Interval:</b> {{interval}} Seconds</div>
+      <div class="owner" v-if="owner.length !== 0"><b>Owner:</b> {{owner}}</div>
+      <div class="severity" v-if="severity.length !== 0"><b>Severity:</b> {{severity}}</div>
+    </template>
+  </b-modal>
+
+</template>
+<script>
+
+
+
+export default {
+  name: "CanaryModal",
+  props: {
+    interval: {
+      type: String,
+      required: true
+    },
+    owner: {
+      type: String,
+      required: true
+    },
+    severity: {
+      type: String,
+      required: true
+    },
+    name: {
+      type: String,
+      required: true
+    },
+    namespace: {
+      type: String,
+      required: true,
+    },
+    description: {
+      type: String,
+      required: true,
+    },
+    checkType: {
+      type: String,
+      required: true,
+    },
+  },
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/statuspage/src/components/CanaryModal.vue
+++ b/statuspage/src/components/CanaryModal.vue
@@ -1,11 +1,12 @@
 <!-- This component encapsulates a modal that is displayed -->
 <!-- when clicking on canary                               -->
 <template>
-<!--  Here we use dynamic id for the modal since it is being called from a loop.-->
-<!--  If ID is not distinguished then a click on any row will open modal for every value-->
+  <!--  Component modal doc: : https://bootstrap-vue.org/docs/components/modal-->
+  <!--  Here we use dynamic id for the modal since it is being called from a loop.-->
+  <!--  If ID is not distinguished then a click on any row will open modal for every value-->
   <b-modal :id="`modal-canary${name}${namespace}`" ok-only>
     <template #modal-title>
-      <img :src="`images/${checkType}.svg`" v-bind:style="{ height: '1.875rem' }" alt=""> {{name}}
+      <img :src="`images/${checkType}.svg`" v-bind:style="{ height: '1.875rem' }" :alt="`${checkType} logo`"> {{name}}
     </template>
     <ul class="list-unstyled">
       <li><b>Name:</b> {{name}}</li>
@@ -16,12 +17,10 @@
       <li><b>Severity:</b> {{getProp(severity)}}</li>
     </ul>
   </b-modal>
-
 </template>
+
+
 <script>
-
-
-
 export default {
   name: "CanaryModal",
   props: {

--- a/statuspage/src/components/CanaryModal.vue
+++ b/statuspage/src/components/CanaryModal.vue
@@ -6,15 +6,15 @@
   <!--  If ID is not distinguished then a click on any row will open modal for every value-->
   <b-modal :id="`modal-canary${name}${namespace}`" ok-only>
     <template #modal-title>
-      <img :src="`images/${checkType}.svg`" v-bind:style="{ height: '1.875rem' }" :alt="`${checkType} logo`"> {{name}}
+      <img :src="`images/${checkType}.svg`" v-bind:style="{ height: '1.875rem' }" alt=""> {{name}}
     </template>
     <ul class="list-unstyled">
-      <li><b>Name:</b> {{name}}</li>
-      <li><b>Namespace:</b> {{namespace}}</li>
-      <li><b>Description:</b> {{description}}</li>
-      <li><b>Interval:</b> {{interval}} Seconds</li>
-      <li><b>Owner:</b> {{getProp(owner)}}</li>
-      <li><b>Severity:</b> {{getProp(severity)}}</li>
+      <li><b>Name:</b> {{ handleMissingValue(name) }}</li>
+      <li><b>Namespace:</b> {{ handleMissingValue(namespace) }}</li>
+      <li><b>Description:</b> {{ handleMissingValue(description) }}</li>
+      <li><b>Interval:</b> {{  handleMissingValue(interval) }} Seconds</li>
+      <li><b>Owner:</b> {{ handleMissingValue(owner) }}</li>
+      <li><b>Severity:</b> {{ handleMissingValue(severity) }}</li>
     </ul>
   </b-modal>
 </template>
@@ -54,11 +54,14 @@ export default {
     },
   },
   methods: {
-    getProp(prop){
-      if (prop.length === 0) {
-        return "-"
+    handleMissingValue(prop){
+      if (prop != null) {
+        if(typeof prop === 'string' && prop.length === 0) {
+          return "-"
+        }
+        return prop
       }
-      return prop
+      return "-"
     }
   }
 }

--- a/statuspage/src/components/CanaryStandardServerRow.vue
+++ b/statuspage/src/components/CanaryStandardServerRow.vue
@@ -2,6 +2,7 @@
 <!-- when clicking on canary                               -->
 <template>
   <tr :key="key">
+    <!--  Component modal doc: : https://bootstrap-vue.org/docs/components/modal-->
     <td v-b-modal="`modal-canary${name}${namespace}`">
       <img :src="`images/${checkType}.svg`" :title="checkType " v-bind:style="{ height: '1.25rem' }" :alt="`${checkType} logo`" >  {{ shortDescription }}
       <canary-modal :interval="interval"
@@ -28,6 +29,7 @@ import CanaryModal from "@/components/CanaryModal";
 import StatusStrip from "@/components/StatusStrip";
 import Vuex from "vuex";
 export default {
+  name: "CanaryStandardServerRow",
   components: {StatusStrip, CanaryModal},
   computed: {
     ...Vuex.mapState([

--- a/statuspage/src/components/TableRow.vue
+++ b/statuspage/src/components/TableRow.vue
@@ -1,0 +1,82 @@
+<!-- This component encapsulates the table rows that is displayed -->
+<!-- when clicking on canary                               -->
+<template>
+  <tr :key="key">
+    <td v-b-modal="`modal-canary${name}${namespace}`">
+      <img :src="`images/${checkType}.svg`" :title="checkType " v-bind:style="{ height: '1.25rem' }" :alt="`${checkType} logo`" >  {{ shortDescription }}
+      <canary-modal :interval="interval"
+                    :owner="owner"
+                    :severity="severity"
+                    :check-type="checkType"
+                    :description="description"
+                    :name="name"
+                    :namespace="namespace"
+      />
+    </td>
+    <td v-for="server in orderedServers" :key="server.value" class="align-top border-right border-left">
+      <div>
+        <status-strip :checks="items" :server="server.value"
+                      color="#28a745" error-color="#dc3545"
+                      :bar-width="20" :bar-spacing="5" :barMaxHeight="20"
+                      :zoominess="0.85"/>
+      </div>
+    </td>
+  </tr>
+</template>
+<script>
+import CanaryModal from "@/components/CanaryModal";
+import StatusStrip from "@/components/StatusStrip";
+import Vuex from "vuex";
+export default {
+  components: {StatusStrip, CanaryModal},
+  computed: {
+    ...Vuex.mapState([
+      "servers",
+    ]),
+    ...Vuex.mapGetters(["orderedServers"]),
+  },
+  props: {
+    interval: {
+      type: String,
+      required: true
+    },
+    owner: {
+      type: String,
+      required: true
+    },
+    severity: {
+      type: String,
+      required: true
+    },
+    name: {
+      type: String,
+      required: true
+    },
+    namespace: {
+      type: String,
+      required: true,
+    },
+    description: {
+      type: String,
+      required: true,
+    },
+    checkType: {
+      type: String,
+      required: true,
+    },
+    shortDescription: {
+      type: String,
+      required: true
+    },
+    items: {
+      type: Array,
+      required: true
+    },
+    key: {
+      type: String,
+      required: true
+    },
+
+  },
+}
+</script>

--- a/statuspage/src/store/index.js
+++ b/statuspage/src/store/index.js
@@ -127,21 +127,16 @@ export default new Vuex.Store({
 
             for (const check of state.checks) {
                 let groupBy = check.name + check.type + check.description
-                if (group[check.namespace] == null) {
-                    group[check.namespace] = {}
-                }
-
-                if (group[check.namespace][groupBy] == null) {
-                    group[check.namespace][groupBy] = {
-                        type: check.type,
-                        namespace: check.namespace,
-                        name: check.name,
-                        interval: check.interval,
-                        severity: check.severity,
-                        owner:    check.owner,
-                        description: check.description,
-                        items: []
-                    }
+                group[check.namespace] = group[check.namespace] ?? {}
+                group[check.namespace][groupBy] = group[check.namespace][groupBy] ?? {
+                    type: check.type,
+                    namespace: check.namespace,
+                    name: check.name,
+                    description: check.description,
+                    interval: check.interval,
+                    severity: check.severity,
+                    owner: check.owner,
+                    items: [],
                 }
 
                 group[check.namespace][groupBy].items.push(check)

--- a/statuspage/src/store/index.js
+++ b/statuspage/src/store/index.js
@@ -135,7 +135,11 @@ export default new Vuex.Store({
                     group[check.namespace][groupBy] = {
                         type: check.type,
                         namespace: check.namespace,
-                        name: check.description ? check.description : check.name,
+                        name: check.name,
+                        interval: check.interval,
+                        severity: check.severity,
+                        owner:    check.owner,
+                        description: check.description,
                         items: []
                     }
                 }


### PR DESCRIPTION
 closes #136

Added a pop-up for the canary. When someone clicks on any canary a popup will open with the canary details
The popup looks like:
<img width="1440" alt="Screenshot 2021-04-08 at 10 36 32 AM" src="https://user-images.githubusercontent.com/36669272/113971398-5411e380-9856-11eb-8006-b593301b60f0.png">


Signed-off-by: Tarun Khandelwal <tarun@flanksource.com>