### PR TITLE
feat: support running most e2e tests locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ docs/cli/
 cover.out
 test.test
 *.tgz
+*.log
+wait4x

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -1,4 +1,4 @@
-name: kind-kind
+name: !!env CLUSTER_NAME
 patches:
   - ./patch1.yaml
 domain: 127.0.0.1.nip.io


### PR DESCRIPTION
There are still some that have logic specific to the CI environment that fail. For example the restic ones require a absolute path to the ca certificate, which hard-codes the path from the CI