### PR TITLE
feat: add junit results mode

### DIFF
--- a/api/v1/canary_types.go
+++ b/api/v1/canary_types.go
@@ -32,6 +32,12 @@ const (
 	postgresDriver = "postgres"
 )
 
+type ResultMode string
+
+const (
+	JunitResultMode = "junit"
+)
+
 // CanarySpec defines the desired state of Canary
 type CanarySpec struct {
 	Env            map[string]VarSource  `yaml:"env,omitempty" json:"env,omitempty"`
@@ -65,10 +71,11 @@ type CanarySpec struct {
 	Interval uint64 `yaml:"interval,omitempty" json:"interval,omitempty"`
 	// Schedule to run checks on. Supports all cron expression, example: '30 3-6,20-23 * * *'. For more info about cron expression syntax see https://en.wikipedia.org/wiki/Cron
 	//  Also supports golang duration, can be set as '@every 1m30s' which runs the check every 1 minute and 30 seconds.
-	Schedule string `yaml:"schedule,omitempty" json:"schedule,omitempty"`
-	Icon     string `yaml:"icon,omitempty" json:"icon,omitempty"`
-	Severity string `yaml:"severity,omitempty" json:"severity,omitempty"`
-	Owner    string `yaml:"owner,omitempty" json:"owner,omitempty"`
+	Schedule   string     `yaml:"schedule,omitempty" json:"schedule,omitempty"`
+	Icon       string     `yaml:"icon,omitempty" json:"icon,omitempty"`
+	Severity   string     `yaml:"severity,omitempty" json:"severity,omitempty"`
+	Owner      string     `yaml:"owner,omitempty" json:"owner,omitempty"`
+	ResultMode ResultMode `yaml:"resultMode,omitempty" json:"resultMode,omitempty"`
 }
 
 func (spec CanarySpec) GetAllChecks() []external.Check {

--- a/checks/common.go
+++ b/checks/common.go
@@ -242,29 +242,27 @@ func template(ctx *context.Context, template v1.Template) (string, error) {
 	return "", nil
 }
 
-func GetJunitReportFromResults(results []*pkg.CheckResult) JunitTestSuites {
-	var testSuites JunitTestSuites
-	for _, result := range results {
-		var suite JunitTestSuite
-		suite.Name = result.Check.GetDescription()
-		suite.Tests = make([]JunitTest, 1)
-		testSuites.Duration += float64(result.Duration) / 1000
-		suite.Duration = float64(result.Duration) / 1000
-		suite.Tests[0].Duration = float64(result.Duration) / 1000
-		suite.Duration = float64(result.Duration) / 1000
-		suite.Tests[0].Classname = result.Check.GetType()
-		suite.Tests[0].Message = result.Message
-		if result.Pass {
-			suite.Passed = 1
-			suite.Tests[0].Status = "passed"
-			testSuites.Passed++
-		} else {
-			suite.Failed = 1
-			testSuites.Failed++
-			suite.Tests[0].Status = "failed"
-			suite.Tests[0].Error = fmt.Errorf(result.Error)
-		}
-		testSuites.Suites = append(testSuites.Suites, suite)
+func GetJunitReportFromResults(canaryName string, results []*pkg.CheckResult) JunitTestSuite {
+	var testSuite = JunitTestSuite{
+		Name: canaryName,
 	}
-	return testSuites
+	for _, result := range results {
+		var test JunitTest
+		test.Classname = result.Check.GetType()
+		test.Name = result.Check.GetDescription()
+		test.Message = result.Message
+		test.Duration = float64(result.Duration) / 1000
+		testSuite.Duration += float64(result.Duration) / 1000
+		if result.Pass {
+			testSuite.Passed++
+			test.Status = "passed"
+		} else {
+			testSuite.Failed++
+			test.Status = "failed"
+			test.Error = fmt.Errorf(result.Error)
+		}
+		testSuite.Duration += float64(result.Duration) / 1000
+		testSuite.Tests = append(testSuite.Tests, test)
+	}
+	return testSuite
 }

--- a/checks/junit_xml.go
+++ b/checks/junit_xml.go
@@ -71,6 +71,11 @@ func (suites JunitTestSuites) GetMessages() string {
 	return message
 }
 
+// func (suites JunitTestSuites) GetDisplayMessage() string {
+// 	var message string
+// 	message = message + "\n" + suites.Totals.String()
+// }
+
 type JunitTestSuites struct {
 	Suites []JunitTestSuite `json:"suites,omitempty"`
 	Totals `json:",inline"`

--- a/checks/junit_xml.go
+++ b/checks/junit_xml.go
@@ -71,11 +71,6 @@ func (suites JunitTestSuites) GetMessages() string {
 	return message
 }
 
-// func (suites JunitTestSuites) GetDisplayMessage() string {
-// 	var message string
-// 	message = message + "\n" + suites.Totals.String()
-// }
-
 type JunitTestSuites struct {
 	Suites []JunitTestSuite `json:"suites,omitempty"`
 	Totals `json:",inline"`

--- a/checks/runchecks.go
+++ b/checks/runchecks.go
@@ -64,21 +64,21 @@ func RunChecks(ctx *context.Context) []*pkg.CheckResult {
 	if ctx.Canary.Spec.ResultMode != "" {
 		switch ctx.Canary.Spec.ResultMode {
 		case v1.JunitResultMode:
-			suites := GetJunitReportFromResults(results)
+			suite := GetJunitReportFromResults(ctx.Canary.GetName(), results)
 			var status = true
-			if suites.Totals.Failed > 0 {
+			if suite.Failed > 0 {
 				status = false
 			}
 			return []*pkg.CheckResult{
 				{
 					Pass:   status,
 					Canary: ctx.Canary,
-					Detail: suites,
+					Detail: suite,
 					Check: v1.JunitCheck{
 						TestResults: "combined",
 						Description: v1.Description{Description: "Result Mode: JUnit Report"},
 					},
-					Message: suites.String(),
+					Message: suite.String(),
 					Start:   time.Now(),
 				},
 			}

--- a/checks/runchecks.go
+++ b/checks/runchecks.go
@@ -1,56 +1,90 @@
 package checks
 
 import (
+	"time"
+
 	"github.com/flanksource/canary-checker/api/context"
 	v1 "github.com/flanksource/canary-checker/api/v1"
 	"github.com/flanksource/canary-checker/pkg"
+	"github.com/flanksource/commons/logger"
 )
 
 func RunChecks(ctx *context.Context) []*pkg.CheckResult {
 	var results []*pkg.CheckResult
 	ctx.Canary.Spec.SetSQLDrivers()
+	// for _, check := range ctx.Canary.Spec.GetAllChecks() {
+
+	// }
+	checks := ctx.Canary.Spec.GetAllChecks()
 	for _, c := range All {
 		// FIXME: this doesn't work correct with DNS,
 		// t := GetDeadline(ctx.Canary)
 		// ctx, cancel := ctx.WithDeadline(t)
 		// defer cancel()
-
-		result := c.Run(ctx)
-		for _, r := range result {
-			if r != nil {
-				if r.Duration == 0 && r.GetDuration() > 0 {
-					r.Duration = r.GetDuration()
-				}
-				switch v := r.Check.(type) {
-				case v1.DisplayTemplate:
-					message, err := template(ctx.New(r.Data), v.GetDisplayTemplate())
-					if err != nil {
-						r.ErrorMessage(err)
-					} else {
-						r.ResultMessage(message)
+		if Checks(checks).Includes(c) {
+			result := c.Run(ctx)
+			for _, r := range result {
+				if r != nil {
+					if r.Duration == 0 && r.GetDuration() > 0 {
+						r.Duration = r.GetDuration()
 					}
-				}
-				switch v := r.Check.(type) {
-				case v1.TestFunction:
-					tpl := v.GetTestFunction()
-					if tpl.IsEmpty() {
-						break
-					}
-					message, err := template(ctx.New(r.Data), tpl)
-					if err != nil {
-						r.ErrorMessage(err)
-					} else if message != "true" {
-						if message != "false" {
-							r.Failf("expecting either 'true' or 'false' but got '%v'", message)
+					switch v := r.Check.(type) {
+					case v1.DisplayTemplate:
+						message, err := template(ctx.New(r.Data), v.GetDisplayTemplate())
+						if err != nil {
+							r.ErrorMessage(err)
 						} else {
-							r.Failf("")
+							r.ResultMessage(message)
 						}
-					} else {
-						ctx.Logger.Tracef("%s return %s", tpl, message)
 					}
+					switch v := r.Check.(type) {
+					case v1.TestFunction:
+						tpl := v.GetTestFunction()
+						if tpl.IsEmpty() {
+							break
+						}
+						message, err := template(ctx.New(r.Data), tpl)
+						if err != nil {
+							r.ErrorMessage(err)
+						} else if message != "true" {
+							if message != "false" {
+								r.Failf("expecting either 'true' or 'false' but got '%v'", message)
+							} else {
+								r.Failf("")
+							}
+						} else {
+							ctx.Logger.Tracef("%s return %s", tpl, message)
+						}
+					}
+					results = append(results, r)
 				}
-				results = append(results, r)
 			}
+		}
+	}
+	if ctx.Canary.Spec.ResultMode != "" {
+		switch ctx.Canary.Spec.ResultMode {
+		case v1.JunitResultMode:
+			suites := GetJunitReportFromResults(results)
+			var status = true
+			if suites.Totals.Failed > 0 {
+				status = false
+			}
+			return []*pkg.CheckResult{
+				{
+					Pass:   status,
+					Canary: ctx.Canary,
+					Detail: suites,
+					Check: v1.JunitCheck{
+						TestResults: "combined",
+						Description: v1.Description{Description: "Result Mode: JUnit Report"},
+					},
+					Message: suites.String(),
+					Start:   time.Now(),
+				},
+			}
+		default:
+			logger.Debugf("Unknown result mode: %s", ctx.Canary.Spec.ResultMode)
+			return results
 		}
 	}
 	return results

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -46,7 +46,6 @@ var Serve = &cobra.Command{
 			logger.Warnf("Failed to get kommons client, features that read kubernetes config will fail: %v", err)
 		}
 		cron := cron.New()
-		cron.Start()
 
 		for _, canary := range configs {
 			if schedule == "" {
@@ -75,6 +74,7 @@ var Serve = &cobra.Command{
 				})
 			}
 		}
+		cron.Start()
 		serve()
 	},
 }

--- a/config/deploy/crd.yaml
+++ b/config/deploy/crd.yaml
@@ -6019,6 +6019,8 @@ spec:
                       - repository
                     type: object
                   type: array
+                resultMode:
+                  type: string
                 s3:
                   items:
                     properties:

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -6026,6 +6026,8 @@ spec:
                       - repository
                     type: object
                   type: array
+                resultMode:
+                  type: string
                 s3:
                   items:
                     properties:

--- a/fixtures/minimal/http_pass_results_mode_pass.yaml
+++ b/fixtures/minimal/http_pass_results_mode_pass.yaml
@@ -1,0 +1,20 @@
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: http-pass
+spec:
+  resultMode: "junit"
+  interval: 30
+  http:
+    - endpoint: https://httpstat.us/200
+      thresholdMillis: 3000
+      responseCodes: [201, 301, 200]
+      responseContent: ""
+      maxSSLExpiry: 7
+      description: "HTTP dummy test 2"
+    - endpoint: https://httpstat.us/201
+      thresholdMillis: 3000
+      responseCodes: [201]
+      responseContent: ""
+      maxSSLExpiry: 7
+      description: "second http check here"

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -97,7 +97,6 @@ func (c *cache) GetChecks(duration string) pkg.Checks {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 	result := pkg.Checks{}
-
 	for _, check := range c.Checks {
 		uptime, latency := metrics.GetMetrics(check.Key)
 		check.Uptime = uptime


### PR DESCRIPTION
Tested the below with the following canary:
```yaml
apiVersion: canaries.flanksource.com/v1
kind: Canary
metadata:
  name: http-pass
spec:
  resultMode: "junit"
  interval: 30
  http:
    - endpoint: https://httpstat.us/200
      thresholdMillis: 3000
      responseCodes: [201, 301, 200]
      responseContent: ""
      maxSSLExpiry: 7
      description: "HTTP dummy test 2"
    - endpoint: https://httpstat.us/201
      thresholdMillis: 3000
      responseCodes: [201]
      responseContent: ""
      maxSSLExpiry: 7
      description: "second http check here"
```
On the UI looks like:

![Screenshot 2021-10-28 at 7 09 48 PM](https://user-images.githubusercontent.com/36669272/139268378-5c9c0140-e4a7-4578-b878-a2d6be0790fc.png)


On the API endpoint:

![Screenshot 2021-10-28 at 7 10 01 PM](https://user-images.githubusercontent.com/36669272/139268530-ca3c0569-88b6-4cda-acd5-f2085b41356e.png)


On the details endpoint:

![Screenshot 2021-10-28 at 7 10 34 PM](https://user-images.githubusercontent.com/36669272/139268596-cf9b7c70-8c9d-439b-bfde-e501e61c062a.png)



