### PR TITLE
fix: set servicemonitor selector labels to match service labels

### DIFF
--- a/chart/templates/servicemonitor.yaml
+++ b/chart/templates/servicemonitor.yaml
@@ -12,5 +12,5 @@ spec:
       interval: 30s
   selector:
     matchLabels:
-      {{- include "canary-checker.selectorLabels" . | nindent 6 }}
+      {{- include "canary-checker.labels" . | nindent 6 }}
 {{- end }}

--- a/go.mod
+++ b/go.mod
@@ -25,8 +25,8 @@ require (
 	github.com/eko/gocache v1.2.1-0.20210528165708-4914d74fed3d
 	github.com/fergusstrange/embedded-postgres v1.15.0
 	github.com/flanksource/changehub/api v0.0.0-20211009193440-b6e0ca984e25
-	github.com/flanksource/commons v1.5.13
-	github.com/flanksource/kommons v0.29.0
+	github.com/flanksource/commons v1.5.14
+	github.com/flanksource/kommons v0.30.0
 	github.com/friendsofgo/errors v0.9.2
 	github.com/go-ldap/ldap/v3 v3.4.1
 	github.com/go-logr/logr v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -446,10 +446,10 @@ github.com/fergusstrange/embedded-postgres v1.15.0 h1:9H5c8Xzp+8nXuEpXKkUPpSyhj7
 github.com/fergusstrange/embedded-postgres v1.15.0/go.mod h1:VqymgzpNsdJspJeISq4+jpqWL1FOrqIzt9o78W5ekkw=
 github.com/flanksource/changehub/api v0.0.0-20211009193440-b6e0ca984e25 h1:PJ53zmJF1NVP8T//btondJbbLL+cXGsIlJuJiHCC0bI=
 github.com/flanksource/changehub/api v0.0.0-20211009193440-b6e0ca984e25/go.mod h1:2cPofGTy3+NA5KvDoroEFyf8e/QPI+lRz/ncY0f3l9M=
-github.com/flanksource/commons v1.5.13 h1:h41g+JmBsRMDiMJl8UeWI+WVbWzra/2ukDoHLZcaDow=
-github.com/flanksource/commons v1.5.13/go.mod h1:TEIeK5ak2VNYgmrYHNSFoX4UjHqQuSXOYvH4waLL5os=
-github.com/flanksource/kommons v0.29.0 h1:xHAcMO0KPcOFSi+Yk3dn//BLOhrzpTb9BGao97U8OWA=
-github.com/flanksource/kommons v0.29.0/go.mod h1:3PSPSJukLZhB7yDc9wmdALrj3B6Hisy02bNZoandDK0=
+github.com/flanksource/commons v1.5.14 h1:XXyLQWmGTJ9re8lBEuETI5txbLItWZWepIEGJn9U/0k=
+github.com/flanksource/commons v1.5.14/go.mod h1:TEIeK5ak2VNYgmrYHNSFoX4UjHqQuSXOYvH4waLL5os=
+github.com/flanksource/kommons v0.30.0 h1:Lvth13vWU/XljAklK7h+gXADH5JNm/3DYf6pKJZWrDg=
+github.com/flanksource/kommons v0.30.0/go.mod h1:MdRCes4kbzPmIo4Uc+0wiTH/eT/YnORUNOEwAWSev7U=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fortytw2/leaktest v1.2.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
@@ -679,7 +679,6 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=


### PR DESCRIPTION
The servicemonitor selector needs to use the labels set on the service, not in the service's selector