### PR TITLE
Feat/show deleted components

### DIFF
--- a/pkg/db/migrations/_always/views.sql
+++ b/pkg/db/migrations/_always/views.sql
@@ -25,7 +25,8 @@ end;
 $$
 language plpgsql;
 
-
+CREATE OR REPLACE VIEW component_names_all AS
+      SELECT id, external_id, type, name, created_at, updated_at, icon, parent_id, deleted_at FROM components WHERE hidden != true ORDER BY name, external_id  ;
 
 CREATE OR REPLACE VIEW component_names AS
       SELECT id, external_id, type, name, created_at, updated_at, icon, parent_id FROM components WHERE deleted_at is null AND hidden != true ORDER BY name, external_id  ;


### PR DESCRIPTION
`component_names_all` query fetches all the components in the database and returns them to the frontend with the `deleted_at` field, in addition to `id, external_id, type, name, created_at, updated_at, icon, and parent_id`. The front end then based on the user request sees either all, deleted, or existing components.