### PR TITLE
chore: Restore http_pass.yaml file in code and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,12 @@ Before installing the Canary Checker, please ensure you have the [prerequisites 
 
 
 ```bash
+# install the Prometheus CRDs
+kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/bundle.yaml --server-side
 # install the operator
 kubectl apply -f https://github.com/flanksource/canary-checker/releases/download/v0.38.154/release.yaml
 # deploy a sample canary
-kubectl apply -f https://raw.githubusercontent.com/flanksource/canary-checker/master/fixtures-crd/http_pass.yaml
+kubectl apply -f https://raw.githubusercontent.com/flanksource/canary-checker/master/fixtures-crd/http/http_pass.yaml
 # check the results of the canary
 kubectl get canary
 ```

--- a/fixtures-crd/http/http_pass.yaml
+++ b/fixtures-crd/http/http_pass.yaml
@@ -1,0 +1,12 @@
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: http-pass
+spec:
+  interval: 30
+  http:
+    - endpoint: https://httpstat.us/200
+      thresholdMillis: 3000
+      responseCodes: [201, 200, 301]
+      responseContent: ""
+      maxSSLExpiry: 7


### PR DESCRIPTION
This PR restores the https_pass.yaml file that is required in the Quick Start section of the documentation. It also ensures that the user installs the Prometheus CRD before installing canary-checker. 

<img width="773" alt="Screenshot 2023-01-16 at 16 18 27" src="https://user-images.githubusercontent.com/12300986/212690321-79f1ecfc-6120-4dce-a4a2-e12471aa73e1.png">
