### PR TITLE
chore: remove old trigger workflow push to sandbox

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,16 +77,6 @@ jobs:
   #       env:
   #         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
   #         MKDOCS_INSIDERS: ${{secrets.MKDOCS_INSIDERS}}
-  trigger:
-    runs-on: ubuntu-latest
-    needs: docker
-    steps:
-      - name: send dispatch
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: flanksource/aws-sandbox
-          event-type: canary-checker-release
   helm:
     runs-on: ubuntu-latest
     needs: [semantic-release, docker]


### PR DESCRIPTION
This trigger was always failing, on closer inspection noticed that we don't use that workflow anymore, so removing the trigger and also the receiver: https://github.com/flanksource/aws-sandbox/pull/95