### PR TITLE
fix: use new embedded db path in chart

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
                   name: {{ .Values.db.external.secretKeyRef.name }}
                   key: {{ .Values.db.external.secretKeyRef.key }}
               {{- else }}
-              value: "embedded:///opt/database/data/"
+              value: "embedded:///opt/database/"
               {{- end }}
           volumeMounts:
             {{- if eq .Values.dockerSocket true }}


### PR DESCRIPTION
Fixes: #945 

The root shouldn't have the `data/` subdirectory included