### PR TITLE
bug: fixing typo in Kustomization

### DIFF
--- a/fixtures/datasources/kustomization.yaml
+++ b/fixtures/datasources/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
   - redis_pass.yaml
   - elasticsearch_fail.yaml
   - elasticsearch_pass.yaml
-  - alertmanager.yaml
+  - alertmanager_fail.yaml


### PR DESCRIPTION
`alertmanager.yaml` to `alertmanager_fail.yaml`