### PR TITLE
fix: handle empty ingress config for pod check 

### DIFF
--- a/fixtures/k8s/pod_pass.yaml
+++ b/fixtures/k8s/pod_pass.yaml
@@ -19,8 +19,6 @@ spec:
               image: quay.io/toni0/hello-webserver-golang:latest
       port: 8080
       path: /foo/bar
-      ingressName: hello-world-golang
-      ingressHost: "hello-world-golang.127.0.0.1.nip.io"
       scheduleTimeout: 20000
       readyTimeout: 10000
       httpTimeout: 7000
@@ -46,8 +44,6 @@ spec:
               imagePullPolicy: Always
       port: 8080
       path: /foo/bar
-      ingressName: hello-world-ruby
-      ingressHost: "hello-world-ruby.127.0.0.1.nip.io"
       scheduleTimeout: 30000
       readyTimeout: 12000
       httpTimeout: 7000


### PR DESCRIPTION
Fixes: https://github.com/flanksource/canary-checker/issues/1028