### PR TITLE
feat: add name suffix for alertmanager check

### DIFF
--- a/build/full/Dockerfile
+++ b/build/full/Dockerfile
@@ -56,9 +56,9 @@ RUN curl -L https://github.com/flanksource/askgit/releases/download/v0.4.8-flank
     tar xf askgit.tar.gz && \
     mv askgit /usr/local/bin/askgit && \
     rm askgit.tar.gz && \
-    wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.18_amd64.deb && \
-    dpkg -i libssl1.1_1.1.1f-1ubuntu2.18_amd64.deb && \
-    rm libssl1.1_1.1.1f-1ubuntu2.18_amd64.deb
+    wget http://mirrors.kernel.org/ubuntu/pool/main/o/openssl/openssl_1.1.1f-1ubuntu2.19_amd64.deb && \
+    dpkg -i openssl_1.1.1f-1ubuntu2.19_amd64.deb && \
+    rm openssl_1.1.1f-1ubuntu2.19_amd64.deb
 
 ENV K6_VERSION=v0.44.0
 RUN curl -L https://github.com/grafana/k6/releases/download/${K6_VERSION}/k6-${K6_VERSION}-linux-amd64.tar.gz -o k6.tar.gz && \


### PR DESCRIPTION
Fixes: https://github.com/flanksource/canary-checker/issues/1013

Names will now look like this:

```
+-------------------------------------------------------------+
| name                                                        |
|-------------------------------------------------------------|
| alertmanager-check                                          |
| KubePodCrashLooping-dev/backend-admin-app-6c4f67756c-sld95  |
| KubeStateMetricsListErrors                                  |
| KubePodNotReady-default/k8s-check-not-ready                 |
| KubeJobFailed-demo/create-postgres-db                       |
| Watchdog                                                    |
| KubeletTooManyPods-ip-10-0-6-69.eu-west-2.compute.internal  |
| KubePodCrashLooping-prod/public-website-777dbd4c57-96wdl    |
| KubePodCrashLooping-prod/backend-admin-app-7b58d4f6b7-h4629 |
| KubeDeploymentReplicasMismatch-dev/public-website           |
| KubePodCrashLooping-dev/public-website-694767fbff-5bbfn     |
| TargetDown                                                  |
| KubeDeploymentReplicasMismatch-platform-system/karina       |
| KubeJobNotCompleted                                         |
| KubeContainerWaiting-default/k8s-check-not-ready/hello      |
+-------------------------------------------------------------+

```