### PR TITLE
fix: add agent_id to check unique clause

### DIFF
--- a/pkg/db/canary.go
+++ b/pkg/db/canary.go
@@ -70,7 +70,7 @@ func PersistCheck(check pkg.Check, canaryID uuid.UUID) (uuid.UUID, error) {
 	check.Name = name
 	check.Description = description
 	tx := Gorm.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "canary_id"}, {Name: "type"}, {Name: "name"}},
+		Columns: []clause.Column{{Name: "canary_id"}, {Name: "type"}, {Name: "name"}, {Name: "agent_id"}},
 		DoUpdates: clause.Assignments(
 			map[string]interface{}{
 				"spec":        check.Spec,


### PR DESCRIPTION
```
2023-06-23T10:13:39.522Z	ERROR	error persisting check with canary 018843b8-45ab-d66a-0c6c-ad6e4995a767: ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification (SQLSTATE 42P10)
```