### PR TITLE
fix: merge canary and check labels for summary api

### DIFF
--- a/pkg/cache/postgres_query.go
+++ b/pkg/cache/postgres_query.go
@@ -186,7 +186,7 @@ SELECT
     checks.description,
     canaries.namespace,
     canaries.name as canaryName,
-    canaries.labels,
+    canaries.labels || checks.labels as labels,
     severity,
     owner,
     last_runtime,


### PR DESCRIPTION
Fixes: https://github.com/flanksource/canary-checker/issues/1115

Fixes: https://mission-control.azure.lab.flanksource.com/incidents/0188e7df-4a98-d640-6bac-729b991c02ab
