### PR TITLE
fix: graph API returns check statuses in chronological order when windowing

### DIFF
--- a/pkg/cache/postgres_query.go
+++ b/pkg/cache/postgres_query.go
@@ -100,8 +100,9 @@ SELECT
   bool_and(status),
   AVG(duration)::integer as duration 
 FROM 
-  grouped_by_window 
+  grouped_by_window
 GROUP BY time
+ORDER BY time
 `
 	args := []any{q.WindowDuration.Seconds() / 2, q.WindowDuration.Seconds(), start, end, q.Check}
 


### PR DESCRIPTION
Resolves: https://github.com/flanksource/canary-checker/issues/1154