### PR TITLE
fix: ignore webhook checks when using delete transformation strategy

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flanksource/canary-checker/pkg/runner"
 	"github.com/flanksource/canary-checker/pkg/telemetry"
 	"github.com/flanksource/commons/logger"
+	"github.com/flanksource/duty"
 	gomplate "github.com/flanksource/gomplate/v3"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -105,6 +106,7 @@ func readFromEnv(v string) string {
 
 func init() {
 	logger.BindFlags(Root.PersistentFlags())
+	duty.BindFlags(Root.PersistentFlags())
 
 	Root.PersistentFlags().StringVar(&db.ConnectionString, "db", "DB_URL", "Connection string for the postgres database")
 	Root.PersistentFlags().BoolVar(&db.RunMigrations, "db-migrations", false, "Run database migrations")

--- a/pkg/api/webhook_test.go
+++ b/pkg/api/webhook_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flanksource/canary-checker/checks"
 	"github.com/flanksource/canary-checker/pkg/db"
 	canaryJobs "github.com/flanksource/canary-checker/pkg/jobs/canary"
+	"github.com/flanksource/canary-checker/pkg/utils"
 	"github.com/flanksource/commons/http"
 	"github.com/flanksource/commons/logger"
 	"github.com/flanksource/duty/job"
@@ -21,6 +22,65 @@ import (
 )
 
 var _ = ginkgo.Describe("Test Sync Canary Job", ginkgo.Ordered, func() {
+	type Alert struct {
+		Status       string            `json:"status"`
+		Name         string            `json:"name"`
+		Labels       map[string]string `json:"labels"`
+		Annotations  map[string]string `json:"annotations"`
+		StartsAt     string            `json:"startsAt"`
+		GeneratorURL string            `json:"generatorURL"`
+		Fingerprint  string            `json:"fingerprint"`
+		EndsAt       *time.Time        `json:"endsAt,omitempty"`
+	}
+
+	type DummyWebhookMessage struct {
+		Version string  `json:"version"`
+		Alerts  []Alert `json:"alerts"`
+	}
+
+	// Create an array of test data with three different Alert data
+	testData := []struct {
+		Msg   Alert
+		Count int
+	}{
+		{
+			Msg: Alert{
+				Status:       "firing",
+				Name:         "ServerDown",
+				Labels:       map[string]string{"severity": "critical", "alertName": "ServerDown", "location": "DataCenterA"},
+				Annotations:  map[string]string{"summary": "Server in DataCenterA is down", "description": "This alert indicates that a server in DataCenterA is currently down."},
+				StartsAt:     "2023-10-30T08:00:00Z",
+				GeneratorURL: "http://example.com/generatorURL/serverdown",
+				Fingerprint:  "a1b2c3d4e5f6",
+			},
+			Count: 1,
+		},
+		{
+			Msg: Alert{
+				Status:       "firing",
+				Name:         "ServerUp",
+				Labels:       map[string]string{"severity": "info", "alertName": "ServerUp", "location": "DataCenterB"},
+				Annotations:  map[string]string{"summary": "Server in DataCenterB is up", "description": "This alert indicates that a server in DataCenterB is currently up."},
+				StartsAt:     "2023-10-31T10:00:00Z",
+				GeneratorURL: "http://example.com/generatorURL/serverup",
+				Fingerprint:  "x1y2z3w4v5u6",
+			},
+			Count: 2,
+		},
+		{
+			Msg: Alert{
+				Status:       "firing",
+				Name:         "HighTraffic",
+				Labels:       map[string]string{"severity": "major", "alertName": "HighTraffic", "location": "DataCenterC"},
+				Annotations:  map[string]string{"summary": "High traffic detected in DataCenterC", "description": "This alert indicates a high level of network traffic in DataCenterC."},
+				StartsAt:     "2023-11-01T15:00:00Z",
+				GeneratorURL: "http://example.com/generatorURL/hightraffic",
+				Fingerprint:  "q1r2s3t4u5v6",
+			},
+			Count: 3,
+		},
+	}
+
 	canarySpec := v1.CanarySpec{
 		Schedule: "@every 1s",
 		HTTP: []v1.HTTPCheck{ // Run another transformed check on the same canary to test that the "delete transform" strategy doesn't delete webhook checks
@@ -141,145 +201,38 @@ var _ = ginkgo.Describe("Test Sync Canary Job", ginkgo.Ordered, func() {
 		Expect(resp.StatusCode).To(Equal(netHTTP.StatusUnauthorized))
 	})
 
-	ginkgo.It("Should allow when webhook is called with the auth token", func() {
-		body := `{
-  "version": "4",
-  "status": "firing",
-  "alerts": [
-    {
-      "status": "firing",
-      "name": "first",
-      "labels": {
-        "severity": "critical",
-        "alertName": "ServerDown",
-        "location": "DataCenterA"
-      },
-      "annotations": {
-        "summary": "Server in DataCenterA is down",
-        "description": "This alert indicates that a server in DataCenterA is currently down."
-      },
-      "startsAt": "2023-10-30T08:00:00Z",
-      "generatorURL": "http://example.com/generatorURL/serverdown",
-      "fingerprint": "a1b2c3d4e5f6"
-    },
-    {
-      "status": "open",
-      "labels": {
-        "severity": "warning",
-        "alertName": "HighCPUUsage",
-        "location": "DataCenterB"
-      },
-      "annotations": {
-        "summary": "High CPU Usage in DataCenterB",
-        "description": "This alert indicates that there was high CPU usage in DataCenterB, but it is now resolved."
-      },
-      "startsAt": "2023-10-30T09:00:00Z",
-      "generatorURL": "http://example.com/generatorURL/highcpuusage", 
-      "name": "second",
-      "fingerprint": "x1y2z3w4v5"
-    }
-  ]
-}`
-		resp, err := client.R(ctx).Post(fmt.Sprintf("/webhook/%s?token=%s", canarySpec.Webhook.Name, canarySpec.Webhook.Token.ValueStatic), body)
-		Expect(err).To(BeNil())
-		Expect(resp.StatusCode).To(Equal(netHTTP.StatusOK))
-	})
+	ginkgo.It("Should call webhook with one alert at a time", func() {
+		for _, td := range testData {
+			resp, err := client.R(ctx).Post(fmt.Sprintf("/webhook/%s?token=%s", canarySpec.Webhook.Name, canarySpec.Webhook.Token.ValueStatic), DummyWebhookMessage{
+				Version: "4",
+				Alerts:  []Alert{td.Msg},
+			})
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(netHTTP.StatusOK))
 
-	ginkgo.It("Should have created 2 new checks from the webhook", func() {
-		var result []models.Check
-		err := testDB.Where("type = ?", checks.WebhookCheckType).Where("name != ?", canarySpec.Webhook.Name).Find(&result).Error
-		Expect(err).To(BeNil())
-		Expect(len(result)).To(Equal(2))
+			var result []models.Check
+			err = testDB.Where("type = ?", checks.WebhookCheckType).Where("deleted_at IS NULL").Where("name != ?", canarySpec.Webhook.Name).Find(&result).Error
+			Expect(err).To(BeNil())
+			Expect(len(result)).To(Equal(td.Count), "should have created new webhook check")
+		}
 	})
 
 	ginkgo.It("Should have deleted one resolved alert from", func() {
-		body := `{
-	"version": "4",
-  "status": "firing",
-  "alerts": [
-    {
-      "status": "firing",
-      "name": "first",
-      "labels": {
-        "severity": "critical",
-        "alertName": "ServerDown",
-        "location": "DataCenterA"
-      },
-      "annotations": {
-        "summary": "Server in DataCenterA is down",
-        "description": "This alert indicates that a server in DataCenterA is currently down."
-      },
-      "startsAt": "2023-10-30T08:00:00Z",
-      "generatorURL": "http://example.com/generatorURL/serverdown",
-      "fingerprint": "a1b2c3d4e5f6",
-      "endsAt": "2023-10-30T09:15:00Z"
-    }
-  ]
-	}`
-		resp, err := client.R(ctx).Post(fmt.Sprintf("/webhook/%s?token=%s", canarySpec.Webhook.Name, canarySpec.Webhook.Token.ValueStatic), body)
+		td := testData[0]
+		td.Msg.Status = "resolved"
+		td.Msg.EndsAt = utils.Ptr(time.Now())
+
+		resp, err := client.R(ctx).Post(fmt.Sprintf("/webhook/%s?token=%s", canarySpec.Webhook.Name, canarySpec.Webhook.Token.ValueStatic), DummyWebhookMessage{
+			Version: "4",
+			Alerts:  []Alert{td.Msg},
+		})
 		Expect(err).To(BeNil())
 		Expect(resp.StatusCode).To(Equal(netHTTP.StatusOK))
 
 		var result models.Check
-		err = testDB.Where("name = 'firsta1b2c3d4e5f6'").Find(&result).Error
+		err = testDB.Where("name = ?", td.Msg.Name+td.Msg.Fingerprint).Find(&result).Error
 		Expect(err).To(BeNil())
 		Expect(result.DeletedAt).To(Not(BeNil()))
-	})
-
-	ginkgo.It("Should create 1 new check from the webhook and deleted one", func() {
-		body := `
-		{
-			"version": "4",
-			"status": "firing",
-			"alerts": [
-				{
-					"status": "resolved",
-					"labels": {
-						"severity": "warning",
-						"alertName": "HighCPUUsage",
-						"location": "DataCenterB"
-					},
-					"annotations": {
-						"summary": "High CPU Usage in DataCenterB",
-						"description": "This alert indicates that there was high CPU usage in DataCenterB, but it is now resolved."
-					},
-					"startsAt": "2023-10-30T09:00:00Z",
-					"generatorURL": "http://example.com/generatorURL/highcpuusage", 
-					"name": "second",
-					"fingerprint": "x1y2z3w4v5",
-					"endsAt": "2023-11-30T09:15:00Z"
-				},
-				{
-					"status": "open",
-					"labels": {
-						"severity": "warning",
-						"alertName": "HighCPUUsage",
-						"location": "DataCenterB"
-					},
-					"annotations": {
-						"summary": "High CPU Usage in DataCenterB",
-						"description": "This alert indicates that there was high CPU usage in DataCenterB, but it is now resolved."
-					},
-					"startsAt": "2023-10-30T09:00:00Z",
-					"generatorURL": "http://example.com/generatorURL/highcpuusage", 
-					"name": "third",
-					"fingerprint": "abc"
-				}
-			]
-		}`
-		resp, err := client.R(ctx).Post(fmt.Sprintf("/webhook/%s?token=%s", canarySpec.Webhook.Name, canarySpec.Webhook.Token.ValueStatic), body)
-		Expect(err).To(BeNil())
-		Expect(resp.StatusCode).To(Equal(netHTTP.StatusOK))
-
-		var result models.Check
-		err = testDB.Where("name = 'thirdabc'").Find(&result).Error
-		Expect(err).To(BeNil())
-		Expect(result.DeletedAt).To(BeNil())
-
-		var activeChecks []models.Check
-		err = testDB.Where("type = ?", checks.WebhookCheckType).Where("deleted_at IS NULL").Where("name != ?", canarySpec.Webhook.Name).Find(&activeChecks).Error
-		Expect(err).To(BeNil())
-		Expect(len(activeChecks)).To(Equal(1), "There should have been just one active webhook check")
 	})
 
 	ginkgo.It("should have deleted the transformed http check", func() {
@@ -297,5 +250,17 @@ var _ = ginkgo.Describe("Test Sync Canary Job", ginkgo.Ordered, func() {
 		err := testDB.Where("name = 'http-check'").Find(&result).Error
 		Expect(err).To(BeNil())
 		Expect(result.DeletedAt).To(Not(BeNil()))
+	})
+
+	ginkgo.It("should have two active and one resolved webhook check", func() {
+		var activeChecks []models.Check
+		err := testDB.Where("type = ?", checks.WebhookCheckType).Where("deleted_at IS NULL").Where("name != ?", canarySpec.Webhook.Name).Find(&activeChecks).Error
+		Expect(err).To(BeNil())
+		Expect(len(activeChecks)).To(Equal(2), "There should have been 2 active webhook check")
+
+		var deletedChecks []models.Check
+		err = testDB.Where("type = ?", checks.WebhookCheckType).Where("deleted_at IS NOT NULL").Where("name != ?", canarySpec.Webhook.Name).Find(&deletedChecks).Error
+		Expect(err).To(BeNil())
+		Expect(len(deletedChecks)).To(Equal(1), "There should have been 1 deleted webhook check")
 	})
 })

--- a/pkg/api/webhook_test.go
+++ b/pkg/api/webhook_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flanksource/canary-checker/pkg/db"
 	canaryJobs "github.com/flanksource/canary-checker/pkg/jobs/canary"
 	"github.com/flanksource/commons/http"
+	"github.com/flanksource/commons/logger"
 	"github.com/flanksource/duty/job"
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/types"
@@ -22,6 +23,30 @@ import (
 var _ = ginkgo.Describe("Test Sync Canary Job", ginkgo.Ordered, func() {
 	canarySpec := v1.CanarySpec{
 		Schedule: "@every 1s",
+		HTTP: []v1.HTTPCheck{ // Run another transformed check on the same canary to test that the "delete transform" strategy doesn't delete webhook checks
+			{
+				Description: v1.Description{
+					Name: "my-http",
+				},
+				Connection: v1.Connection{
+					URL: fmt.Sprintf("http://localhost:%d/http-check", testEchoServerPort),
+				},
+				Templatable: v1.Templatable{
+					Transform: v1.Template{
+						Expression: `
+							json.alerts.map(r,
+								{
+									'name': r.name,
+									'icon': r.icon,
+									'message': r.message,
+									'description': r.description,
+									'deletedAt': has(r.deleted_at) ? r.deleted_at : null,
+								}
+							).toJSON()`,
+					},
+				},
+			},
+		},
 		Webhook: &v1.WebhookCheck{
 			Description: v1.Description{
 				Name: "my-webhook",
@@ -72,6 +97,8 @@ var _ = ginkgo.Describe("Test Sync Canary Job", ginkgo.Ordered, func() {
 	})
 
 	ginkgo.It("schedule the canary job", func() {
+		canaryJobs.MinimumTimeBetweenCanaryRuns = 0 // reset this for now so it doesn't hinder test with small schedules
+
 		canaryJobs.CanaryScheduler.Start()
 		jobCtx := job.JobRuntime{
 			Context: ctx,
@@ -99,6 +126,13 @@ var _ = ginkgo.Describe("Test Sync Canary Job", ginkgo.Ordered, func() {
 				ginkgo.Fail("expected check to be created")
 			}
 		}
+	})
+
+	ginkgo.It("Should have created the transformed http check", func() {
+		var transformedChecks []models.Check
+		err := ctx.DB().Where("transformed = true").Where("type = 'http'").Find(&transformedChecks).Error
+		Expect(err).To(BeNil())
+		Expect(len(transformedChecks)).To(Equal(1))
 	})
 
 	ginkgo.It("Should forbid when webhook is called without the auth token", func() {
@@ -129,7 +163,7 @@ var _ = ginkgo.Describe("Test Sync Canary Job", ginkgo.Ordered, func() {
       "fingerprint": "a1b2c3d4e5f6"
     },
     {
-      "status": "resolved",
+      "status": "open",
       "labels": {
         "severity": "warning",
         "alertName": "HighCPUUsage",
@@ -188,6 +222,79 @@ var _ = ginkgo.Describe("Test Sync Canary Job", ginkgo.Ordered, func() {
 
 		var result models.Check
 		err = testDB.Where("name = 'firsta1b2c3d4e5f6'").Find(&result).Error
+		Expect(err).To(BeNil())
+		Expect(result.DeletedAt).To(Not(BeNil()))
+	})
+
+	ginkgo.It("Should create 1 new check from the webhook and deleted one", func() {
+		body := `
+		{
+			"version": "4",
+			"status": "firing",
+			"alerts": [
+				{
+					"status": "resolved",
+					"labels": {
+						"severity": "warning",
+						"alertName": "HighCPUUsage",
+						"location": "DataCenterB"
+					},
+					"annotations": {
+						"summary": "High CPU Usage in DataCenterB",
+						"description": "This alert indicates that there was high CPU usage in DataCenterB, but it is now resolved."
+					},
+					"startsAt": "2023-10-30T09:00:00Z",
+					"generatorURL": "http://example.com/generatorURL/highcpuusage", 
+					"name": "second",
+					"fingerprint": "x1y2z3w4v5",
+					"endsAt": "2023-11-30T09:15:00Z"
+				},
+				{
+					"status": "open",
+					"labels": {
+						"severity": "warning",
+						"alertName": "HighCPUUsage",
+						"location": "DataCenterB"
+					},
+					"annotations": {
+						"summary": "High CPU Usage in DataCenterB",
+						"description": "This alert indicates that there was high CPU usage in DataCenterB, but it is now resolved."
+					},
+					"startsAt": "2023-10-30T09:00:00Z",
+					"generatorURL": "http://example.com/generatorURL/highcpuusage", 
+					"name": "third",
+					"fingerprint": "abc"
+				}
+			]
+		}`
+		resp, err := client.R(ctx).Post(fmt.Sprintf("/webhook/%s?token=%s", canarySpec.Webhook.Name, canarySpec.Webhook.Token.ValueStatic), body)
+		Expect(err).To(BeNil())
+		Expect(resp.StatusCode).To(Equal(netHTTP.StatusOK))
+
+		var result models.Check
+		err = testDB.Where("name = 'thirdabc'").Find(&result).Error
+		Expect(err).To(BeNil())
+		Expect(result.DeletedAt).To(BeNil())
+
+		var activeChecks []models.Check
+		err = testDB.Where("type = ?", checks.WebhookCheckType).Where("deleted_at IS NULL").Where("name != ?", canarySpec.Webhook.Name).Find(&activeChecks).Error
+		Expect(err).To(BeNil())
+		Expect(len(activeChecks)).To(Equal(1), "There should have been just one active webhook check")
+	})
+
+	ginkgo.It("should have deleted the transformed http check", func() {
+		for {
+			if httpCheckCallCounter <= 1 {
+				time.Sleep(time.Second)
+				continue
+			}
+
+			break
+		}
+
+		logger.Debugf("http check endpoint was called %d times", httpCheckCallCounter)
+		var result models.Check
+		err := testDB.Where("name = 'http-check'").Find(&result).Error
 		Expect(err).To(BeNil())
 		Expect(result.DeletedAt).To(Not(BeNil()))
 	})

--- a/pkg/jobs/canary/canary_jobs.go
+++ b/pkg/jobs/canary/canary_jobs.go
@@ -66,7 +66,7 @@ func (j CanaryJob) GetNamespacedName() types.NamespacedName {
 	return types.NamespacedName{Name: j.Canary.Name, Namespace: j.Canary.Namespace}
 }
 
-var minimumTimeBetweenCanaryRuns = 10 * time.Second
+var MinimumTimeBetweenCanaryRuns = 10 * time.Second
 var canaryLastRuntimes = sync.Map{}
 
 func (j CanaryJob) Run(ctx dutyjob.JobRuntime) error {
@@ -89,7 +89,7 @@ func (j CanaryJob) Run(ctx dutyjob.JobRuntime) error {
 	}
 	defer lock.Unlock()
 
-	lastRunDelta := minimumTimeBetweenCanaryRuns
+	lastRunDelta := MinimumTimeBetweenCanaryRuns
 	// Get last runtime from sync map
 	var lastRuntime time.Time
 	if lastRuntimeVal, exists := canaryLastRuntimes.Load(canaryID); exists {
@@ -98,7 +98,7 @@ func (j CanaryJob) Run(ctx dutyjob.JobRuntime) error {
 	}
 
 	// Skip run if job ran too recently
-	if lastRunDelta < minimumTimeBetweenCanaryRuns {
+	if lastRunDelta < MinimumTimeBetweenCanaryRuns {
 		logger.Infof("Skipping Canary[%s]:%s since it last ran %.2f seconds ago", canaryID, j.Canary.GetNamespacedName(), lastRunDelta.Seconds())
 		return nil
 	}

--- a/pkg/jobs/canary/canary_jobs_test.go
+++ b/pkg/jobs/canary/canary_jobs_test.go
@@ -53,7 +53,7 @@ var _ = ginkgo.Describe("Test Sync Canary Job", ginkgo.Ordered, func() {
 
 	ginkgo.It("schedule the canary job", func() {
 		CanaryScheduler.Start()
-		minimumTimeBetweenCanaryRuns = 0 // reset this for now so it doesn't hinder test with small schedules
+		MinimumTimeBetweenCanaryRuns = 0 // reset this for now so it doesn't hinder test with small schedules
 		ctx := context.NewContext(gocontext.Background()).WithDB(db.Gorm, db.Pool)
 		jobCtx := job.JobRuntime{
 			Context: ctx,


### PR DESCRIPTION
resolves: https://github.com/flanksource/canary-checker/issues/1423