### PR TITLE
feat: persist webhook checks even if there's no schedule

### DIFF
--- a/fixtures/external/alertmanager.yaml
+++ b/fixtures/external/alertmanager.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     "Expected-Fail": "true"
 spec:
-  schedule: "@every 1m"
+  # schedule: "@every 1m" # (Not required for webhook checks)
   webhook:
     name: my-webhook
     token:


### PR DESCRIPTION
resolves: https://github.com/flanksource/canary-checker/issues/1417