### PR TITLE
chore: add sync topology job to scheduler

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -56,7 +56,7 @@ func Start() {
 		}
 	}
 
-	for _, j := range []*job.Job{topologyJobs.CleanupComponents} {
+	for _, j := range []*job.Job{topologyJobs.CleanupComponents, topologyJobs.SyncTopology} {
 		var job = j
 		job.Context = context.DefaultContext
 		if err := job.AddToScheduler(FuncScheduler); err != nil {


### PR DESCRIPTION
@moshloop FYI this also missing leading to those database topology jobs not getting scheduled