### PR TITLE
fix: deprecate templatebody from http check

### DIFF
--- a/api/v1/checks.go
+++ b/api/v1/checks.go
@@ -196,7 +196,8 @@ type HTTPCheck struct {
 	Body string `yaml:"body,omitempty" json:"body,omitempty" template:"true"`
 	// Header fields to be used in the query
 	Headers []types.EnvVar `yaml:"headers,omitempty" json:"headers,omitempty"`
-	// Template the request body
+	// Template the request body.
+	// Deprecated: Body is always templated by default. Use template escaping if necessary.
 	TemplateBody bool `yaml:"templateBody,omitempty" json:"templateBody,omitempty"`
 	// EnvVars are the environment variables that are accessible to templated body
 	EnvVars []types.EnvVar `yaml:"env,omitempty" json:"env,omitempty"`

--- a/checks/http.go
+++ b/checks/http.go
@@ -237,12 +237,13 @@ func hydrate(ctx *context.Context, check v1.HTTPCheck) (*v1.HTTPCheck, *models.C
 
 	check.URL = uri
 
-	body := check.Body
 	if check.TemplateBody {
-		body, err = template(ctx, v1.Template{Template: body})
-		if err != nil {
-			return nil, nil, oops, results.WithError(oops.Wrap(err)).Invalidf("failed to template request body: %v", err)
-		}
+		ctx.Tracef("TemplateBody is deprecated. The body is templated by default. Use template escaping if necessary.")
+	}
+
+	body, err := template(ctx, v1.Template{Template: check.Body})
+	if err != nil {
+		return nil, nil, oops, results.WithError(oops.Wrap(err)).Invalidf("failed to template request body: %v", err)
 	}
 
 	oops = oops.Hint(body)

--- a/config/deploy/Canary.yml
+++ b/config/deploy/Canary.yml
@@ -3947,7 +3947,7 @@ spec:
                           - value
                         type: object
                       templateBody:
-                        description: Template the request body
+                        description: 'Template the request body. Deprecated: Body is always templated by default. Use template escaping if necessary.'
                         type: boolean
                       test:
                         properties:

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -3946,7 +3946,7 @@ spec:
                           - value
                         type: object
                       templateBody:
-                        description: Template the request body
+                        description: 'Template the request body. Deprecated: Body is always templated by default. Use template escaping if necessary.'
                         type: boolean
                       test:
                         properties:


### PR DESCRIPTION
resolves: https://github.com/flanksource/canary-checker/issues/1584