### PR TITLE
fix: windows service script & postgres shutdown

### DIFF
--- a/install-service.ps1
+++ b/install-service.ps1
@@ -1,21 +1,32 @@
  param (
     [string]$configfile = "$pwd\canary-checker.yaml",
     [int]$httpPort = 8080,
-    [int]$metricsPort = 8081,
     [string]$name = "local",
-    [switch]$uninstall = $false,
-    [string]$pushServers
+
+    [ValidateSet('install','reinstall','uninstall')]
+    [System.String]$Operation = 'install'
  )
 
-
+ if ([System.Environment]::OSVersion.Platform -inotmatch "Win32NT"){
+    Write-Warning "This script is for windows OS only"
+    exit -99
+}
+ if (($Operation -match "(re|un)install") -And $null -eq (get-service -Name canary-checker -ErrorAction SilentlyContinue)) {
+    Write-Warning "Service does not exist, cannot perform $Operation, first try -operation install"
+    exit -1
+ } elseif (($Operation -eq "install") -And $null -ne (get-service -Name canary-checker -ErrorAction SilentlyContinue)) {
+    Write-Warning "Service already installed, try '-operation uninstall' Or '-operation re-install'"
+    exit -2
+ }
 
 Write-Host "Checking current priviledges"
 If (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(`
 [Security.Principal.WindowsBuiltInRole] "Administrator"))
 {
     Write-Warning "You do not have Administrator rights to run this script!`nPlease re-run this script as an Administrator!"
-    exit
+    exit -3
 }
+
 
 Write-Host "Installing nssm for use"
 
@@ -26,20 +37,54 @@ if (!(Test-Path  ".\nssm-2.24\win64\nssm.exe"))
      expand-archive -path '.\nssm-2.24.zip' -destinationpath '.'
 }
 
-if (!(Test-Path ".\canary-checker.exe") ) {
+$scriptpath = $MyInvocation.MyCommand.Path
+$dir = Split-Path $scriptpath
+$existing_exe = "$dir\canary-checker.exe"
+
+if ((Test-Path $existing_exe) -And !(Test-Path ".\canary-checker.exe")){
+    Write-host "canary-checker exe found in this script path $existing_exe , using this exe version, no need to download from internet"
+    if ($pwd -ne $dir ) {
+        Write-Host "Current working path not the same as current script path, copying executable to here $pwd"
+        copy-item $existing_exe $pwd
+    }
+} elseif (!(Test-Path ".\canary-checker.exe") ) {
+    Write-host "canary-checker not found in $pwd, will attempt internet download"
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     Invoke-WebRequest -Uri https://github.com/flanksource/canary-checker/releases/latest/download/canary-checker.exe -OutFile canary-checker.exe
 }
 
-$path="$pwd\canary-checker.exe"
 
-if ($uninstall) {
+
+
+if (!(Test-Path ".\\canary-checker.exe"))
+{
+    Write-Warning "Failed finding canary-checker executable"
+    exit -4
+}
+
+if ( !(Test-Path $configfile)){
+    Write-Warning "Failed finding canary-checker config file in $configfile, please specify a valid config file location"
+    exit -5
+}
+
+if (!(Test-Path "$pwd\postgres-db")) {
+    Write-Host "Creating folder for postgres data files - $pwd\postgres-db"
+    New-Item -Path $pwd -Name "postgres-db" -ItemType "directory"
+}
+$dbpath = "$($pwd.path.Replace("\","/"))/postgres-db"
+
+
+if ($Operation -match "((re|un)install)") {
     .\nssm-2.24\win64\nssm.exe stop canary-checker
     .\nssm-2.24\win64\nssm.exe remove canary-checker confirm
-} else {
-    .\nssm-2.24\win64\nssm.exe install canary-checker "$path"
-    .\nssm-2.24\win64\nssm.exe set canary-checker AppParameters "serve --configfile $configfile --httpPort $httpPort --metricsPort $metricsPort --name $name --push-servers=$pushServers"
+} 
+
+if ($Operation -ne "uninstall") {
+    .\nssm-2.24\win64\nssm.exe install canary-checker "$pwd\canary-checker.exe"
+    .\nssm-2.24\win64\nssm.exe set canary-checker AppParameters "serve $configfile --httpPort $httpPort --name $name --db embedded://$dbpath --db-migrations"
     .\nssm-2.24\win64\nssm.exe set canary-checker DisplayName "Canary Checker Server"
     .\nssm-2.24\win64\nssm.exe set canary-checker Description "Starts the Canary Checker Server"
     .\nssm-2.24\win64\nssm.exe start canary-checker
 }
+
+exit 0


### PR DESCRIPTION
2 Main Fixes

1. Fixed windows powershell script by doing the following
  1.1 Removed deprecated options
  1.2 Added Postgres local storage location creation
  1.3 Added skip DB migrations option to prevent crash
  1.4 Added parameter to install, uninstall & reinstall to make these operations easier
  1.5 Added ability to use local canary-checker executable if one exists, prevent needless download & allow for installing custom build

2. Fixed Postgres not shutdown, this is due to log.fatal after Postgres started. Fix is to simply explicitly call shutdown before these statements. 