### PR TITLE
chore: add default schedule for topology

### DIFF
--- a/pkg/db/topology.go
+++ b/pkg/db/topology.go
@@ -16,10 +16,17 @@ import (
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 )
 
+const (
+	DefaultTopologySchedule = "@every 10m"
+)
+
 func PersistV1Topology(ctx context.Context, t *v1.Topology) (bool, error) {
 	var err error
 	var changed bool
 
+	if t.Spec.Schedule == "" {
+		t.Spec.Schedule = DefaultTopologySchedule
+	}
 	model := pkg.TopologyFromV1(t)
 	if t.GetPersistedID() != "" {
 		model.ID, err = uuid.Parse(t.GetPersistedID())

--- a/pkg/jobs/topology/topology_jobs.go
+++ b/pkg/jobs/topology/topology_jobs.go
@@ -31,6 +31,9 @@ func newTopologyJob(ctx context.Context, topology pkg.Topology) {
 		Topology:  *v1,
 		Namespace: topology.Namespace,
 	}
+	if v1.Spec.Schedule == "" {
+		v1.Spec.Schedule = db.DefaultTopologySchedule
+	}
 	j := &job.Job{
 		Name:         "Topology",
 		Context:      ctx.WithObject(v1.ObjectMeta).WithTopology(v1),


### PR DESCRIPTION
Fixes: https://github.com/flanksource/canary-checker/issues/1625