### PR TITLE
chore: fix k8s kustomization

### DIFF
--- a/fixtures/k8s/kustomization.yaml
+++ b/fixtures/k8s/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
   - _setup.yaml
   - junit_fail.yaml
   - junit_pass.yaml
-  - namespace_pass.yaml
+  - slow/namespace_pass.yaml
   - pod_fail.yaml
   - pod_pass.yaml
   - kubernetes_bundle.yaml


### PR DESCRIPTION
```
canaries   148d   False   kustomize build failed: accumulating resources: accumulation err='accumulating resources from 'k8s': read /tmp/kustomization-2520510114/fixtures/k8s: is a directory': recursed accumulation of path '/tmp/kustomization-2520510114/fixtures/k8s': accumulating resources: accumulation err='accumulating resources from 'namespace_pass.yaml': open /tmp/kustomization-2520510114/fixtures/k8s/namespace_pass.yaml: no such file or directory': must build at directory: not a valid directory: evalsymlink failure on '/tmp/kustomization-2520510114/fixtures/k8s/namespace_pass.yaml' : lstat /tmp/kustomization-2520510114/fixtures/k8s/namespace_pass.yaml: no such file or directory
```