### PR TITLE
fix: Update deployment.yaml for embedded DB option

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
                   name: {{ if .Values.global.db.connectionPooler.enabled }}{{ .Values.global.db.connectionPooler.secretKeyRef.name }}{{ else }}{{ .Values.db.external.secretKeyRef.name }}{{ end }}
                   key: {{ if .Values.global.db.connectionPooler.enabled }}{{ .Values.global.db.connectionPooler.secretKeyRef.key }}{{ else }}{{ .Values.db.external.secretKeyRef.key }}{{ end }}
               {{- else }}
-              value: "embedded:///opt/database/"
+              value: "embedded:///opt/database/data/"
               {{- end }}
           {{- if .Values.upstream.secretKeyRef.name }}
           envFrom:


### PR DESCRIPTION
_Appears to by resolved as of 1.0.258, though an upgrade in place does not seem to resolve._

**Helm chart release version(s):** 1.0.257 - 1.0.258-beta.9
**Issue:**
Enbedded postgres server created with:
postgres using /opt/database/bin/bin/pg_ctl start -w -D /opt/database/data -o -p 6432:

URL previously pointed to /opt/database/ causing crash reboot

**Steps to recreate:**
use the following values.yaml with the above versions
```
db:
  runMigrations: true
  embedded:
  # If the database is embedded, setting this to true will persist the contents of the database
  # through a persistent volume
    persist: true
    storageClass: ""
    storage: 20Gi
```

**Suggestions:**
update default embedded database URL to /opt/database/data