### PR TITLE
fix: sslmode for default database setup

### DIFF
--- a/chart/templates/postgres-secret.yaml
+++ b/chart/templates/postgres-secret.yaml
@@ -15,7 +15,7 @@ stringData:
   {{- $password := (( get $secretInj "POSTGRES_PASSWORD" ) | b64dec ) | default (( get $secretObj "POSTGRES_PASSWORD" ) | b64dec ) | default ( randAlphaNum 32 ) }}
   {{- $host := print "postgres." .Release.Namespace  ".svc.cluster.local" }}
   {{- $url := print "postgresql://" $user ":" $password "@" $host }}
-  {{- $canaryCheckerUrl := ( get $secretObj .Values.db.external.secretKeyRef.key ) | default ( print $url "/canarychecker" ) }}
+  {{- $canaryCheckerUrl := ( get $secretObj .Values.db.external.secretKeyRef.key ) | default ( print $url "/canarychecker?sslmode=disable" ) }}
   POSTGRES_USER: {{ $user | quote }}
   POSTGRES_PASSWORD: {{ $password | quote }}
   POSTGRES_HOST: {{ $host | quote }}


### PR DESCRIPTION
Fixes: https://github.com/flanksource/canary-checker/issues/1766