### PR TITLE
chore: fix labels for postgres in helm chart

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -33,20 +33,36 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Common labels
 */}}
-{{- define "canary-checker.labels" -}}
+{{- define "chart.labels" -}}
 helm.sh/chart: {{ include "canary-checker.chart" . }}
-{{ include "canary-checker.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
+{{- define "canary-checker.labels" -}}
+{{ include "chart.labels" . }}
+{{ include "canary-checker.selectorLabels" . }}
+{{- end }}
+
+{{- define "postgresql.labels" -}}
+{{ include "chart.labels" . }}
+{{ include "postgresql.selectorLabels" . }}
+{{- end }}
+
+
 {{/*
 Selector labels
 */}}
 {{- define "canary-checker.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "canary-checker.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+control-plane: canary-checker
+{{- end }}
+
+{{- define "postgresql.selectorLabels" -}}
+app.kubernetes.io/name: postgresql
 app.kubernetes.io/instance: {{ .Release.Name }}
 control-plane: canary-checker
 {{- end }}

--- a/chart/templates/postgres-service.yaml
+++ b/chart/templates/postgres-service.yaml
@@ -4,11 +4,11 @@ kind: Service
 metadata:
   name: postgres
   labels:
-    {{- include "canary-checker.labels" . | nindent 4 }}
+    {{- include "postgresql.labels" . | nindent 4 }}
 spec:
   selector:
     app: postgresql
-    {{- include "canary-checker.selectorLabels" . | nindent 4 }}
+    {{- include "postgresql.selectorLabels" . | nindent 4 }}
   ports:
   - port: 5432
     targetPort: 5432

--- a/chart/templates/postgres-statefulset.yaml
+++ b/chart/templates/postgres-statefulset.yaml
@@ -4,19 +4,19 @@ kind: StatefulSet
 metadata:
   name: postgresql
   labels:
-    {{- include "canary-checker.labels" . | nindent 4 }}
+    {{- include "postgresql.labels" . | nindent 4 }}
 spec:
   serviceName: postgresql
   selector:
     matchLabels:
       app: postgresql
-      {{- include "canary-checker.selectorLabels" . | nindent 6 }}
+      {{- include "postgresql.selectorLabels" . | nindent 6 }}
   replicas: 1
   template:
     metadata:
       labels:
         app: postgresql
-        {{- include "canary-checker.labels" . | nindent 8 }}
+        {{- include "postgresql.selectorLabels" . | nindent 8 }}
     spec:
       containers:
       - name: postgresql


### PR DESCRIPTION
Fixes: https://github.com/flanksource/canary-checker/issues/1765