### PR TITLE
fix(kubernetes check): race condition

### DIFF
--- a/checks/kubernetes_resource.go
+++ b/checks/kubernetes_resource.go
@@ -208,7 +208,7 @@ func (c *KubernetesResourceChecker) evalWaitFor(ctx *context.Context, check v1.K
 				got = append(got, fmt.Sprintf("%s/%s/%s", r.GetKind(), r.GetNamespace(), r.GetName()))
 			}
 
-			return fmt.Errorf("unxpected error. expected %d resources, got %d (%s)", check.TotalResources(), len(resourceObjs), strings.Join(got, ","))
+			return fmt.Errorf("unexpected error. expected %d resources, got %d (%s)", check.TotalResources(), len(resourceObjs), strings.Join(got, ","))
 		}
 
 		waitForExpr := check.WaitFor.Expr

--- a/fixtures/k8s/kubernetes_resource_pod_exit_code_pass.yaml
+++ b/fixtures/k8s/kubernetes_resource_pod_exit_code_pass.yaml
@@ -16,7 +16,7 @@ spec:
         - apiVersion: v1
           kind: Pod
           metadata:
-            name: hello-world
+            name: "hello-world-{{strings.ToLower (random.Alpha 10)}}"
             namespace: default
           spec:
             restartPolicy: Never
@@ -24,7 +24,7 @@ spec:
               - name: hello-world
                 image: hello-world
       waitFor:
-        expr: 'dyn(resources).all(r, k8s.isHealthy(r))'
+        expr: "dyn(resources).all(r, k8s.isHealthy(r))"
         interval: "1s"
         timeout: "20s"
       checkRetries:
@@ -37,7 +37,7 @@ spec:
               namespaceSelector:
                 name: default
               resource:
-                name: hello-world
+                name: "{{(index .resources 0).Object.metadata.name}}"
               test:
                 expr: >
                   size(results) == 1 &&


### PR DESCRIPTION
* fix: when fetching multiple resources concurrently, we were writing to a slice from multiple goroutines resulting in a race condition. Changed it to use a channel.
* fix: changed `ClientByKind` to `ClientByGroupVersionKind`
* Removed unused method `WaitForResource`
* use templating in the fixture