### PR TITLE
fix: otel labels in helm chart

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -76,9 +76,9 @@ spec:
           image: {{ include "canary-checker.imageString" . }}
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           env:
-            {{- if .Values.otel.labels}}
+            {{- if (tpl .Values.otel.labels .)}}
             - name: OTEL_LABELS
-              value: '{{ .Values.otel.labels }}'
+              value: '{{ tpl .Values.otel.labels .}}'
             {{- end}}
             - name: PING_MODE
               value:  {{ .Values.pingMode | quote }}


### PR DESCRIPTION
So it can use the global value when being used as a subchart