### PR TITLE
feat: add display for kubernetes resource check

### DIFF
--- a/api/v1/checks.go
+++ b/api/v1/checks.go
@@ -972,6 +972,16 @@ type KubernetesResourceCheck struct {
 	WaitFor KubernetesResourceCheckWaitFor `json:"waitFor,omitempty"`
 }
 
+func (c KubernetesResourceCheck) GetDisplayTemplate() Template {
+	if !c.Templatable.Display.IsEmpty() {
+		return c.Templatable.Display
+	}
+
+	return Template{
+		Expression: "display.keys().map(k, k + ': ' + display[k]).join('\n')",
+	}
+}
+
 func (c KubernetesResourceCheck) TotalResources() int {
 	return len(c.Resources) + len(c.StaticResources)
 }

--- a/canary-checker.properties
+++ b/canary-checker.properties
@@ -5,3 +5,4 @@
 # check.disabled.tcp=false
 
 # topology.runNow=true
+log.level.db=warn

--- a/checks/kubernetes_resource.go
+++ b/checks/kubernetes_resource.go
@@ -109,6 +109,8 @@ func (c *KubernetesResourceChecker) Check(ctx context.Context, check v1.Kubernet
 	}
 
 	ctx.Logger.V(4).Infof("found %d checks to run", len(check.Checks))
+
+	displayPerCheck := map[string]string{}
 	for _, c := range check.Checks {
 		virtualCanary := v1.Canary{
 			ObjectMeta: ctx.Canary.ObjectMeta,
@@ -167,6 +169,9 @@ func (c *KubernetesResourceChecker) Check(ctx context.Context, check v1.Kubernet
 				}
 			}
 
+			for _, r := range res {
+				displayPerCheck[r.Check.GetName()] = r.Message
+			}
 			return nil
 		})
 		if retryErr != nil {
@@ -174,6 +179,9 @@ func (c *KubernetesResourceChecker) Check(ctx context.Context, check v1.Kubernet
 		}
 	}
 
+	result.AddData(map[string]any{
+		"display": displayPerCheck,
+	})
 	return results
 }
 

--- a/fixtures/k8s/kubernetes_resource_pod_exit_code_pass.yaml
+++ b/fixtures/k8s/kubernetes_resource_pod_exit_code_pass.yaml
@@ -12,6 +12,9 @@ spec:
     - name: "pod exit code"
       description: "Create pod & check its exit code"
       namespace: default
+      display:
+        expr: |
+          "Result of check 'exit-code-check': " + display["exit-code-check"]
       resources:
         - apiVersion: v1
           kind: Pod


### PR DESCRIPTION
resolves: https://github.com/flanksource/canary-checker/issues/2086

---

On the display template of a **kubernetes resource check**, a new `display: map[string]string` variable is made available. The `display` variable contains the display output of all of the checks defined within the kubernetes resource check.

A default display expression is also added for **kubernetes resource check** _(which I think should probably be added to all the checks)_.

```
display.keys().map(k, k + ': ' + display[k]).join(' | ')
```

This expression simply concats `<check name>: <display> | <check name>: <display> ...`
Example: here's the display of 3 checks 

![image](https://github.com/user-attachments/assets/722ffeb2-4e86-4d0c-a068-5d9222f87b14)
