### PR TITLE
fix: nil map entry when watch namespace is enabled

### DIFF
--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -103,6 +103,9 @@ func run(cmd *cobra.Command, args []string) {
 	}
 
 	if runner.WatchNamespace != "" {
+		if managerOpt.Cache.DefaultNamespaces == nil {
+			managerOpt.Cache.DefaultNamespaces = make(map[string]ctrlCache.Config)
+		}
 		managerOpt.Cache.DefaultNamespaces[runner.WatchNamespace] = ctrlCache.Config{}
 	}
 


### PR DESCRIPTION
```
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/flanksource/canary-checker/cmd.run(0xc013e86200?, {0x6efbe09?, 0x4?, 0x6efbe0d?})
	/app/cmd/operator.go:106 +0x765
github.com/spf13/cobra.(*Command).execute(0xa9b0400, {0xc000a03030, 0x7, 0x7})
	/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0xab1
github.com/spf13/cobra.(*Command).ExecuteC(0xa9afe40)
```