### PR TITLE
feat: limit check status duration to maxInt32 milliseconds.

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -60,7 +60,7 @@ func init() {
 	Push.Flags().StringVar(&status.Error, "error", "", "Error of check")
 	Push.Flags().StringVar(&status.Message, "message", "", "Message of check")
 	Push.Flags().StringVar(&details, "detail", "", "Detail of check")
-	Push.Flags().Int64Var(&status.DurationMs, "duration", 0, "Duration of check in milliseconds")
+	Push.Flags().Int32Var(&status.DurationMs, "duration", 0, "Duration of check in milliseconds")
 	Push.Flags().BoolVar(&status.Status, "passed", true, "Passed status of check")
 	Root.AddCommand(Push)
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -60,8 +60,7 @@ func init() {
 	Push.Flags().StringVar(&status.Error, "error", "", "Error of check")
 	Push.Flags().StringVar(&status.Message, "message", "", "Message of check")
 	Push.Flags().StringVar(&details, "detail", "", "Detail of check")
-	Push.Flags().IntVar(&status.Duration, "duration", 0, "Duration of check in milliseconds")
-	// Push.Flags().StringVar(&status.Time, "time", "", "Time of check")
+	Push.Flags().Int64Var(&status.DurationMs, "duration", 0, "Duration of check in milliseconds")
 	Push.Flags().BoolVar(&status.Status, "passed", true, "Passed status of check")
 	Root.AddCommand(Push)
 }

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -50,14 +50,14 @@ func (t *JSONTime) UnmarshalJSON(b []byte) error {
 }
 
 type CheckStatus struct {
-	Status   bool            `json:"status"`
-	Invalid  bool            `json:"invalid,omitempty"`
-	Time     string          `json:"time"`
-	Duration int             `json:"duration"`
-	Message  string          `json:"message,omitempty"`
-	Error    string          `json:"error,omitempty"`
-	Detail   interface{}     `json:"-"`
-	Check    *external.Check `json:"check,omitempty"`
+	Status     bool            `json:"status"`
+	Invalid    bool            `json:"invalid,omitempty"`
+	Time       string          `json:"time"`
+	DurationMs int64           `json:"duration"`
+	Message    string          `json:"message,omitempty"`
+	Error      string          `json:"error,omitempty"`
+	Detail     interface{}     `json:"-"`
+	Check      *external.Check `json:"check,omitempty"`
 }
 
 func (s CheckStatus) GetTime() (time.Time, error) {
@@ -194,14 +194,14 @@ func FromExternalCheck(canary Canary, check external.Check) Check {
 
 func CheckStatusFromResult(result CheckResult) CheckStatus {
 	return CheckStatus{
-		Status:   result.Pass,
-		Invalid:  result.Invalid,
-		Duration: int(result.Duration),
-		Time:     time.Now().UTC().Format(time.RFC3339),
-		Message:  result.Message,
-		Error:    result.Error,
-		Detail:   result.Detail,
-		Check:    &result.Check,
+		Status:     result.Pass,
+		Invalid:    result.Invalid,
+		DurationMs: result.Duration,
+		Time:       time.Now().UTC().Format(time.RFC3339),
+		Message:    result.Message,
+		Error:      result.Error,
+		Detail:     result.Detail,
+		Check:      &result.Check,
 	}
 }
 

--- a/pkg/cache/postgres.go
+++ b/pkg/cache/postgres.go
@@ -97,7 +97,7 @@ func (c *postgresCache) AddCheckStatus(conn *gorm.DB, check pkg.Check, status pk
 		`,
 		checks[0].ID,
 		string(jsonDetails),
-		status.Duration,
+		status.DurationMs,
 		status.Error,
 		status.Invalid,
 		status.Message,


### PR DESCRIPTION
resolves: https://github.com/flanksource/canary-checker/issues/2059