### PR TITLE
fix: attempt multiple time formats when parsing triggerAt

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -152,3 +152,23 @@ func FreePort() int {
 	address := listener.Addr().(*net.TCPAddr)
 	return address.Port
 }
+
+func ParseTime(t string) *time.Time {
+	formats := []string{
+		time.RFC3339,
+		time.RFC3339Nano,
+		time.ANSIC,
+		time.DateTime,
+		"2006-01-02T15:04:05", // ISO8601 without timezone
+		"2006-01-02 15:04:05", // MySQL datetime format
+	}
+
+	for _, format := range formats {
+		parsed, err := time.Parse(format, t)
+		if err == nil {
+			return &parsed
+		}
+	}
+
+	return nil
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+)
+
+func TestParseTime(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected *time.Time
+	}{
+		{
+			name:     "RFC3339",
+			input:    "2023-04-05T15:04:05Z",
+			expected: lo.ToPtr(time.Date(2023, 4, 5, 15, 4, 5, 0, time.UTC)),
+		},
+		{
+			name:     "RFC3339Nano",
+			input:    "2023-04-05T15:04:05.999999999Z",
+			expected: lo.ToPtr(time.Date(2023, 4, 5, 15, 4, 5, 999999999, time.UTC)),
+		},
+		{
+			name:     "ISO8601 with timezone",
+			input:    "2023-04-05T15:04:05+02:00",
+			expected: lo.ToPtr(time.Date(2023, 4, 5, 15, 4, 5, 0, time.FixedZone("", 2*60*60))),
+		},
+		{
+			name:     "ISO8601 without timezone",
+			input:    "2023-04-05T15:04:05",
+			expected: lo.ToPtr(time.Date(2023, 4, 5, 15, 4, 5, 0, time.UTC)),
+		},
+		{
+			name:     "MySQL datetime format",
+			input:    "2023-04-05 15:04:05",
+			expected: lo.ToPtr(time.Date(2023, 4, 5, 15, 4, 5, 0, time.UTC)),
+		},
+		{
+			name:     "Invalid format",
+			input:    "not a valid time",
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ParseTime(tc.input)
+			if tc.expected == nil {
+				if result != nil {
+					t.Errorf("Expected nil, but got %v", result)
+				}
+			} else {
+				if result == nil {
+					t.Errorf("Expected %v, but got nil", tc.expected)
+				} else if !result.Equal(*tc.expected) {
+					t.Errorf("Expected %v, but got %v", tc.expected, result)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
resolves: https://github.com/flanksource/canary-checker/issues/2060