### PR TITLE
fix: ignore URL field when templating kubernetes resource

### DIFF
--- a/checks/kubernetes_resource.go
+++ b/checks/kubernetes_resource.go
@@ -123,6 +123,9 @@ func (c *KubernetesResourceChecker) Check(ctx context.Context, check v1.Kubernet
 				"resources":       check.Resources,
 			},
 			ValueFunctions: true,
+			IgnoreFields: map[string]string{
+				"URL": "string", // Avoid templating URL which might have non-templated username, password etc.
+			},
 			DelimSets: []gomplate.Delims{
 				{Left: "{{", Right: "}}"},
 				{Left: "$(", Right: ")"},


### PR DESCRIPTION
Fixes: https://github.com/flanksource/canary-checker/issues/2267