### PR TITLE
fix(kubernetes-resource): handle default display template error in case of timeout

### DIFF
--- a/checks/kubernetes_resource.go
+++ b/checks/kubernetes_resource.go
@@ -149,6 +149,12 @@ func (c *KubernetesResourceChecker) Check(ctx context.Context, check v1.Kubernet
 			backoff = retry.WithMaxDuration(maxRetryTimeout, backoff)
 		}
 
+		// We do this before virtual check run in case the check times out
+		// and returns an err, the default templating requires 'display' in env
+		result.AddData(map[string]any{
+			"display": make(map[string]any),
+		})
+
 		retryErr := retry.Do(ctx, backoff, func(_ctx gocontext.Context) error {
 			ctx.Logger.V(4).Infof("running check: %s", virtualCanary.Name)
 


### PR DESCRIPTION
Fixes: https://github.com/flanksource/canary-checker/issues/2268