### PR TITLE
fix: add additional properties in crd for metrics obj

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ manifests: .bin/controller-gen .bin/yq
 		$(YQ) ea 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.checks.items.properties)' crd.yaml | \
 		$(YQ) ea 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.forEach.properties)' /dev/stdin | \
 		$(YQ) ea 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.[].items.properties.metrics.items.properties)' /dev/stdin | \
+		$(YQ) ea '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties[] |= (select(.items.properties.metrics != null) | .items.properties.metrics.items.additionalProperties = true)' /dev/stdin | \
 		$(YQ) ea 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.lookup.properties)' /dev/stdin | \
 		$(YQ) ea 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.properties.items.properties.lookup.properties)' /dev/stdin | \
 		$(YQ) ea 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.components.items.properties.forEach.properties)' /dev/stdin | \

--- a/config/deploy/crd.yaml
+++ b/config/deploy/crd.yaml
@@ -120,6 +120,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -492,6 +493,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -877,6 +879,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -1212,6 +1215,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -1510,6 +1514,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -1852,6 +1857,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -2259,6 +2265,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -2466,6 +2473,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -2750,6 +2758,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -2980,6 +2989,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       minrecords:
                         type: integer
@@ -3290,6 +3300,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -3582,6 +3593,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -3843,6 +3855,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -4087,6 +4100,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -4949,6 +4963,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -5419,6 +5434,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       minAge:
                         description: MinAge the latest object should be older than defined age
@@ -5867,6 +5883,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -6234,6 +6251,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -6553,6 +6571,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -6873,6 +6892,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -7370,6 +7390,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -7633,6 +7654,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -7879,6 +7901,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -8178,6 +8201,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -8504,6 +8528,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -8771,6 +8796,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -9068,6 +9094,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -9201,6 +9228,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -9531,6 +9559,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -9873,6 +9902,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -10119,6 +10149,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -10466,6 +10497,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -10701,6 +10733,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -11076,6 +11109,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -11635,6 +11669,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -11985,6 +12020,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -12333,6 +12369,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check
@@ -12639,6 +12676,7 @@ spec:
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
                           type: object
+                          additionalProperties: true
                         type: array
                       name:
                         description: Name of the check

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -118,6 +118,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -490,6 +491,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -875,6 +877,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -1210,6 +1213,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -1508,6 +1512,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -1850,6 +1855,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -2257,6 +2263,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -2464,6 +2471,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -2748,6 +2756,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -2978,6 +2987,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       minrecords:
@@ -3288,6 +3298,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -3580,6 +3591,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -3841,6 +3853,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -4085,6 +4098,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -4947,6 +4961,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -5417,6 +5432,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       minAge:
@@ -5865,6 +5881,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -6232,6 +6249,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -6551,6 +6569,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -6871,6 +6890,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -7368,6 +7388,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -7631,6 +7652,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -7877,6 +7899,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -8176,6 +8199,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -8502,6 +8526,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -8769,6 +8794,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -9066,6 +9092,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -9199,6 +9226,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -9529,6 +9557,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -9871,6 +9900,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -10117,6 +10147,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -10464,6 +10495,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -10699,6 +10731,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -11074,6 +11107,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -11633,6 +11667,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -11983,6 +12018,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -12331,6 +12367,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:
@@ -12637,6 +12674,7 @@ spec:
                           Metrics to expose from check.
                           https://canarychecker.io/concepts/metrics-exporter
                         items:
+                          additionalProperties: true
                           type: object
                         type: array
                       name:


### PR DESCRIPTION
```yaml
apiVersion: canaries.flanksource.com/v1
kind: Canary
metadata:
  name: domain
spec:
  schedule: "@every 1m"
  http:
    - name: myDomain
      url: https://mydomain.com/
      thresholdMillis: 20000
      responseCodes: [201, 200, 301]
      metrics:
        - name: canary_checker_custom_http_status
          type: gauge
          value: "1"
          labels:
            - name: check_name
              valueExpr: check.name
            - name: url
              valueExpr: check.url
```

Was giving this error (Reported on Slack)

```
Error from server (BadRequest): error when creating "myDomain.yaml": Canary in version "v1" cannot be handled as a Canary: strict decoding error: unknown field "spec.http[0].metrics[0].labels", unknown field "spec.http[0].metrics[0].name", unknown field "spec.http[0].metrics[0].type", unknown field "spec.http[0].metrics[0].value"
```