### PR TITLE
feat: wait for checks before shutdown

### DIFF
--- a/canary-checker.properties
+++ b/canary-checker.properties
@@ -6,5 +6,6 @@
 
 # topology.runNow=true
 log.level.db=warn
+# check.concurrency=100
 
 # jobs.ComponentRelationshipSync.runNow=true

--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -96,6 +96,10 @@ func run() error {
 		// so we use a goroutine to unblock server start
 		// to prevent health check from failing
 		go jobs.Start()
+
+		shutdown.AddHookWithPriority("check jobs", shutdown.PriorityJobs, func() {
+			canaryJobs.AcquireAllCheckLocks(ctx)
+		})
 	}
 
 	go serve()

--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -92,14 +92,14 @@ func run() error {
 	if runner.OperatorExecutor {
 		logger.Infof("Starting executors")
 
+		shutdown.AddHookWithPriority("check jobs", shutdown.PriorityJobs, func() {
+			canaryJobs.AcquireAllCheckLocks(ctx)
+		})
+
 		// Some synchronous jobs can take time
 		// so we use a goroutine to unblock server start
 		// to prevent health check from failing
 		go jobs.Start()
-
-		shutdown.AddHookWithPriority("check jobs", shutdown.PriorityJobs, func() {
-			canaryJobs.AcquireAllCheckLocks(ctx)
-		})
 	}
 
 	go serve()

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -49,6 +49,10 @@ var Serve = &cobra.Command{
 		canaryJobs.StartScanCanaryConfigs(apicontext.DefaultContext, dataFile, configFiles)
 		if executor {
 			jobs.Start()
+
+			shutdown.AddHookWithPriority("check jobs", shutdown.PriorityJobs, func() {
+				canaryJobs.AcquireAllCheckLocks(apicontext.DefaultContext)
+			})
 		}
 
 		serve()

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -48,11 +48,11 @@ var Serve = &cobra.Command{
 
 		canaryJobs.StartScanCanaryConfigs(apicontext.DefaultContext, dataFile, configFiles)
 		if executor {
-			jobs.Start()
-
 			shutdown.AddHookWithPriority("check jobs", shutdown.PriorityJobs, func() {
 				canaryJobs.AcquireAllCheckLocks(apicontext.DefaultContext)
 			})
+
+			jobs.Start()
 		}
 
 		serve()

--- a/pkg/jobs/canary/sync.go
+++ b/pkg/jobs/canary/sync.go
@@ -23,23 +23,46 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-const propertyCheckConcurrency = "check.concurrency"
-
-var (
-	// The maximum number of checks that can run concurrently
-	defaultCheckConcurrency = 50
-
-	// Holds in the lock for every running check.
-	// Can be overwritten by 'check.concurrency' property.
-	globalCheckSemaphore *semaphore.Weighted
+const (
+	propertyCheckConcurrency = "check.concurrency"
+	defaultCheckConcurrency  = 50
 )
 
-// AcquireAllCheckLocks blocks until the global check sempahore is fully acquired.
+var (
+	globalCheckSemaphoreLock sync.Mutex
+
+	// Holds one lock for every running check.
+	// Can be overwritten by the 'check.concurrency' property.
+	globalCheckSemaphore      *semaphore.Weighted
+	globalCheckSemaphoreLimit int64
+)
+
+func getGlobalCheckSemaphore(ctx context.Context) (*semaphore.Weighted, int64) {
+	globalCheckSemaphoreLock.Lock()
+	defer globalCheckSemaphoreLock.Unlock()
+
+	if globalCheckSemaphore != nil {
+		return globalCheckSemaphore, globalCheckSemaphoreLimit
+	}
+
+	concurrency := ctx.Properties().Int(propertyCheckConcurrency, defaultCheckConcurrency)
+	if concurrency < 1 {
+		ctx.Warnf("invalid %s=%d, using default %d", propertyCheckConcurrency, concurrency, defaultCheckConcurrency)
+		concurrency = defaultCheckConcurrency
+	}
+
+	globalCheckSemaphoreLimit = int64(concurrency)
+	globalCheckSemaphore = semaphore.NewWeighted(globalCheckSemaphoreLimit)
+	return globalCheckSemaphore, globalCheckSemaphoreLimit
+}
+
+// AcquireAllCheckLocks blocks until the global check semaphore is fully acquired.
 //
 // This helps to ensure that no checks are currently running.
 func AcquireAllCheckLocks(ctx context.Context) {
 	ctx.Logger.V(6).Infof("acquiring all check locks")
-	if err := globalCheckSemaphore.Acquire(ctx, int64(ctx.Properties().Int(propertyCheckConcurrency, defaultCheckConcurrency))); err != nil {
+	checkSemaphore, limit := getGlobalCheckSemaphore(ctx)
+	if err := checkSemaphore.Acquire(ctx, limit); err != nil {
 		ctx.Logger.Errorf("failed to acquire check semaphores: %v", err)
 	}
 	ctx.Logger.V(6).Infof("acquired all check locks")
@@ -165,21 +188,21 @@ func SyncCanaryJob(ctx context.Context, dbCanary pkg.Canary) error {
 	}
 
 	if existingJob == nil {
-		return newCanaryJob(canaryJob)
+		return newCanaryJob(ctx, canaryJob)
 	}
 
 	existingCanary := existingJob.Context.Value("canary")
 	if existingCanary != nil && !reflect.DeepEqual(existingCanary.(v1.Canary).Spec, canary.Spec) {
 		ctx.Debugf("Rescheduling %s canary with updated specs", canary)
 		Unschedule(id)
-		return newCanaryJob(canaryJob)
+		return newCanaryJob(ctx, canaryJob)
 	}
 
 	ctx.Logger.V(2).Infof("canary %s was not rescheduled", canary.Name)
 	return nil
 }
 
-func newCanaryJob(c CanaryJob) error {
+func newCanaryJob(ctx context.Context, c CanaryJob) error {
 	schedule := c.Canary.Spec.Schedule
 	if schedule == "" && c.Canary.Spec.Interval > 0 {
 		schedule = fmt.Sprintf("@every %ds", c.Canary.Spec.Interval)
@@ -187,6 +210,8 @@ func newCanaryJob(c CanaryJob) error {
 	if schedule == "" {
 		schedule = DefaultCanarySchedule
 	}
+
+	checkSemaphore, _ := getGlobalCheckSemaphore(ctx)
 
 	j := &job.Job{
 		Name:                 "Canary",
@@ -198,7 +223,7 @@ func newCanaryJob(c CanaryJob) error {
 		IgnoreSuccessHistory: true,
 		Retention:            job.RetentionBalanced,
 		ResourceID:           c.DBCanary.ID.String(),
-		Semaphores:           []*semaphore.Weighted{globalCheckSemaphore},
+		Semaphores:           []*semaphore.Weighted{checkSemaphore},
 		ResourceType:         "canary",
 		ID:                   fmt.Sprintf("%s/%s", c.Canary.Namespace, c.Canary.Name),
 		Fn:                   c.Run,
@@ -220,9 +245,7 @@ var SyncCanaryJobs = &job.Job{
 	Schedule:   "@every 5m",
 	Retention:  job.RetentionFew,
 	Fn: func(ctx job.JobRuntime) error {
-		if globalCheckSemaphore == nil {
-			globalCheckSemaphore = semaphore.NewWeighted(int64(ctx.Properties().Int(propertyCheckConcurrency, defaultCheckConcurrency)))
-		}
+		getGlobalCheckSemaphore(ctx.Context)
 
 		canaries, err := db.GetAllCanariesForSync(ctx.Context, runner.WatchNamespace)
 		if err != nil {

--- a/pkg/jobs/canary/sync.go
+++ b/pkg/jobs/canary/sync.go
@@ -20,7 +20,30 @@ import (
 	"github.com/flanksource/duty/job"
 	"github.com/flanksource/duty/models"
 	"github.com/robfig/cron/v3"
+	"golang.org/x/sync/semaphore"
 )
+
+const propertyCheckConcurrency = "check.concurrency"
+
+var (
+	// The maximum number of checks that can run concurrently
+	defaultCheckConcurrency = 50
+
+	// Holds in the lock for every running check.
+	// Can be overwritten by 'check.concurrency' property.
+	globalCheckSemaphore *semaphore.Weighted
+)
+
+// AcquireAllCheckLocks blocks until the global check sempahore is fully acquired.
+//
+// This helps to ensure that no checks are currently running.
+func AcquireAllCheckLocks(ctx context.Context) {
+	ctx.Logger.V(6).Infof("acquiring all check locks")
+	if err := globalCheckSemaphore.Acquire(ctx, int64(ctx.Properties().Int(propertyCheckConcurrency, defaultCheckConcurrency))); err != nil {
+		ctx.Logger.Errorf("failed to acquire check semaphores: %v", err)
+	}
+	ctx.Logger.V(6).Infof("acquired all check locks")
+}
 
 var canaryJobs sync.Map
 
@@ -175,6 +198,7 @@ func newCanaryJob(c CanaryJob) error {
 		IgnoreSuccessHistory: true,
 		Retention:            job.RetentionBalanced,
 		ResourceID:           c.DBCanary.ID.String(),
+		Semaphores:           []*semaphore.Weighted{globalCheckSemaphore},
 		ResourceType:         "canary",
 		ID:                   fmt.Sprintf("%s/%s", c.Canary.Namespace, c.Canary.Name),
 		Fn:                   c.Run,
@@ -196,6 +220,10 @@ var SyncCanaryJobs = &job.Job{
 	Schedule:   "@every 5m",
 	Retention:  job.RetentionFew,
 	Fn: func(ctx job.JobRuntime) error {
+		if globalCheckSemaphore == nil {
+			globalCheckSemaphore = semaphore.NewWeighted(int64(ctx.Properties().Int(propertyCheckConcurrency, defaultCheckConcurrency)))
+		}
+
 		canaries, err := db.GetAllCanariesForSync(ctx.Context, runner.WatchNamespace)
 		if err != nil {
 			return err


### PR DESCRIPTION
resolves: https://github.com/flanksource/canary-checker/issues/2221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable concurrency control for canary check jobs, helping limit how many run at once.
  * Included a default setting for check-job concurrency that can be adjusted in configuration.

* **Bug Fixes**
  * Improved shutdown behavior so canary check jobs are properly handled during service exit, reducing the chance of lingering work or lock issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->