### PR TITLE
chore: allow arbitary args in chart rbac

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -104,6 +104,9 @@ rules:
     verbs:
       - "*"
   {{- end}}
+  {{- if .Values.serviceAccount.rbac.extra }}
+  {{ .Values.serviceAccount.rbac.extra | toYaml | nindent 2 }}
+  {{- end}}
   - apiGroups:
       - "metrics.k8s.io"
     resources:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -502,6 +502,16 @@
               "title": "exec",
               "type": "boolean"
             },
+            "extra": {
+              "default": [],
+              "items": {
+                "required": [],
+                "type": "object"
+              },
+              "required": [],
+              "title": "extra",
+              "type": "array"
+            },
             "ingressCreateAndDelete": {
               "default": true,
               "description": "for pod canary",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -430,6 +430,15 @@ serviceAccount:
     # -- for namespace canary
     namespaceCreateAndDelete: true
 
+    # @schema
+    # required: false
+    # default: []
+    # type: array
+    # items:
+    #   type: object
+    # @schema
+    extra: []
+
 # @schema
 # type: array
 # required: false


### PR DESCRIPTION
Fixes: https://github.com/flanksource/canary-checker/issues/2271

@moshloop Should we allow specific args for managing flux resources or argo resources or having an "extra" is fine ?

This is being added for the helm resource tutorial, by default canary checker cannot create flux resources