### PR TITLE
fix: formatting of the quick start canary check in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ helm install \
 
 2. Create a new check
 
-  ```yaml title="canary.yaml"
+```yaml title="canary.yaml"
 apiVersion: canaries.flanksource.com/v1
 kind: Canary
 metadata:
@@ -62,7 +62,7 @@ spec:
       url: https://httpbin.demo.aws.flanksource.com/status/200
     - name: failing-check
       url: https://httpbin.demo.aws.flanksource.com/status/500
-  ```
+```
 
 2a. Run the check locally (Optional)
 


### PR DESCRIPTION
The indents come out slightly off if copied from README as is. This is to fix the formatting.

It's pretty clear in the rich diff of this commit: https://github.com/flanksource/canary-checker/pull/2301/files?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5