### PR TITLE
feat: Add RBAC rules for Kubernetes Deployment tests

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -92,6 +92,7 @@ Kubernetes native, multi-tenant synthetic monitoring system
 | serviceAccount.rbac.exec | bool | `true` |  |
 | serviceAccount.rbac.ingressCreateAndDelete | bool | `true` | for pod canary |
 | serviceAccount.rbac.namespaceCreateAndDelete | bool | `true` | for namespace canary |
+| serviceAccount.rbac.deploymentCreateAndDelete | bool | `true` | for deployment canary |
 | serviceAccount.rbac.podsCreateAndDelete | bool | `true` | for pod and junit canaries |
 | serviceAccount.rbac.readAll | bool | `true` | for use with kubernetes resource lookups |
 | serviceAccount.rbac.secrets | bool | `true` | for secret management with valueFrom |

--- a/chart/ci/full-values.yaml
+++ b/chart/ci/full-values.yaml
@@ -73,6 +73,7 @@ serviceAccount:
     exec: true
     ingressCreateAndDelete: true
     namespaceCreateAndDelete: true
+    deploymentCreateAndDelete: true
     podsCreateAndDelete: true
     readAll: true
     secrets: true

--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -4,7 +4,7 @@ kind: "{{if .Values.serviceAccount.rbac.clusterRole}}Cluster{{end}}Role"
 metadata:
   name: {{ include "canary-checker.name" . }}-role
 rules:
-  {{- if .Values.serviceAccount.rbac.secrets}}
+  {{- if .Values.serviceAccount.rbac.secrets }}
   - apiGroups:
       - ""
     resources:
@@ -12,8 +12,8 @@ rules:
     verbs:
       - get
       - list
-  {{- end}}
-  {{- if .Values.serviceAccount.rbac.configmaps}}
+  {{- end }}
+  {{- if .Values.serviceAccount.rbac.configmaps }}
   - apiGroups:
       - ""
     resources:
@@ -21,8 +21,8 @@ rules:
     verbs:
       - get
       - list
-  {{- end}}
-  {{- if .Values.serviceAccount.rbac.exec}}
+  {{- end }}
+  {{- if .Values.serviceAccount.rbac.exec }}
   - apiGroups: [""]
     resources:
       - pods/attach
@@ -30,16 +30,16 @@ rules:
       - pods/log
     verbs:
       - '*'
-  {{- end}}
-  {{- if .Values.serviceAccount.rbac.tokenRequest}}
+  {{- end }}
+  {{- if .Values.serviceAccount.rbac.tokenRequest }}
   - apiGroups:
       - authentication.k8s.io
     resources:
       - serviceaccounts/token
     verbs:
       - create
-  {{- end}}
-  {{- if .Values.serviceAccount.rbac.readAll}}
+  {{- end }}
+  {{- if .Values.serviceAccount.rbac.readAll }}
   - apiGroups:
       - "*"
     resources:
@@ -48,7 +48,7 @@ rules:
       - list
       - get
       - watch
-  {{- end}}
+  {{- end }}
   - apiGroups:
       - canaries.flanksource.com
     resources:
@@ -71,7 +71,7 @@ rules:
       - get
       - patch
       - update
-  {{- if .Values.serviceAccount.rbac.podsCreateAndDelete}}
+  {{- if .Values.serviceAccount.rbac.podsCreateAndDelete }}
   # for creating and destroying pods during the pod canary test
   - apiGroups:
       - ""
@@ -81,7 +81,7 @@ rules:
       - services
     verbs:
       - "*"
-  {{- end}}
+  {{- end }}
   {{- if .Values.serviceAccount.rbac.ingressCreateAndDelete }}
   - apiGroups:
       - "networking.k8s.io"
@@ -95,7 +95,7 @@ rules:
       - ingresses
     verbs:
       - "*"
-  {{- end}}
+  {{- end }}
   {{- if .Values.serviceAccount.rbac.namespaceCreateAndDelete }}
   - apiGroups:
       - ""
@@ -103,10 +103,20 @@ rules:
       - namespaces
     verbs:
       - "*"
-  {{- end}}
+  {{- end }}
+  {{- if .Values.serviceAccount.rbac.deploymentCreateAndDelete }}
+  # for creating and deleting deployments
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+  {{- end }}
   {{- if .Values.serviceAccount.rbac.extra }}
   {{ .Values.serviceAccount.rbac.extra | toYaml | nindent 2 }}
-  {{- end}}
+  {{- end }}
   - apiGroups:
       - "metrics.k8s.io"
     resources:
@@ -162,4 +172,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}
     namespace: {{ .Release.Namespace }}
-{{- end}}
+{{- end }}

--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -48,7 +48,7 @@ rules:
       - list
       - get
       - watch
-  {{- end }}
+  {{- end}}
   - apiGroups:
       - canaries.flanksource.com
     resources:
@@ -120,7 +120,7 @@ rules:
   {{- end }}
   {{- if .Values.serviceAccount.rbac.extra }}
   {{ .Values.serviceAccount.rbac.extra | toYaml | nindent 2 }}
-  {{- end }}
+  {{- end}}
   - apiGroups:
       - "metrics.k8s.io"
     resources:

--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -4,7 +4,7 @@ kind: "{{if .Values.serviceAccount.rbac.clusterRole}}Cluster{{end}}Role"
 metadata:
   name: {{ include "canary-checker.name" . }}-role
 rules:
-  {{- if .Values.serviceAccount.rbac.secrets }}
+  {{- if .Values.serviceAccount.rbac.secrets}}
   - apiGroups:
       - ""
     resources:
@@ -12,8 +12,8 @@ rules:
     verbs:
       - get
       - list
-  {{- end }}
-  {{- if .Values.serviceAccount.rbac.configmaps }}
+  {{- end}}
+  {{- if .Values.serviceAccount.rbac.configmaps}}
   - apiGroups:
       - ""
     resources:
@@ -21,8 +21,8 @@ rules:
     verbs:
       - get
       - list
-  {{- end }}
-  {{- if .Values.serviceAccount.rbac.exec }}
+  {{- end}}
+  {{- if .Values.serviceAccount.rbac.exec}}
   - apiGroups: [""]
     resources:
       - pods/attach
@@ -30,16 +30,16 @@ rules:
       - pods/log
     verbs:
       - '*'
-  {{- end }}
-  {{- if .Values.serviceAccount.rbac.tokenRequest }}
+  {{- end}}
+  {{- if .Values.serviceAccount.rbac.tokenRequest}}
   - apiGroups:
       - authentication.k8s.io
     resources:
       - serviceaccounts/token
     verbs:
       - create
-  {{- end }}
-  {{- if .Values.serviceAccount.rbac.readAll }}
+  {{- end}}
+  {{- if .Values.serviceAccount.rbac.readAll}}
   - apiGroups:
       - "*"
     resources:
@@ -71,7 +71,7 @@ rules:
       - get
       - patch
       - update
-  {{- if .Values.serviceAccount.rbac.podsCreateAndDelete }}
+  {{- if .Values.serviceAccount.rbac.podsCreateAndDelete}}
   # for creating and destroying pods during the pod canary test
   - apiGroups:
       - ""
@@ -81,7 +81,7 @@ rules:
       - services
     verbs:
       - "*"
-  {{- end }}
+  {{- end}}
   {{- if .Values.serviceAccount.rbac.ingressCreateAndDelete }}
   - apiGroups:
       - "networking.k8s.io"
@@ -95,7 +95,7 @@ rules:
       - ingresses
     verbs:
       - "*"
-  {{- end }}
+  {{- end}}
   {{- if .Values.serviceAccount.rbac.namespaceCreateAndDelete }}
   - apiGroups:
       - ""
@@ -103,15 +103,19 @@ rules:
       - namespaces
     verbs:
       - "*"
-  {{- end }}
+  {{- end}}
   {{- if .Values.serviceAccount.rbac.deploymentCreateAndDelete }}
-  # for creating and deleting deployments
   - apiGroups:
       - "apps"
     resources:
       - deployments
     verbs:
+      - get
+      - list
+      - watch
       - create
+      - update
+      - patch
       - delete
   {{- end }}
   {{- if .Values.serviceAccount.rbac.extra }}
@@ -172,4 +176,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}
     namespace: {{ .Release.Namespace }}
-{{- end }}
+{{- end}}

--- a/chart/values.schema.deref.json
+++ b/chart/values.schema.deref.json
@@ -4388,6 +4388,12 @@
               "title": "namespaceCreateAndDelete",
               "type": "boolean"
             },
+            "deploymentCreateAndDelete": {
+              "default": true,
+              "description": "for deployment canary",
+              "title": "deploymentCreateAndDelete",
+              "type": "boolean"
+            },
             "podsCreateAndDelete": {
               "default": true,
               "description": "for pod and junit canaries",
@@ -4422,7 +4428,8 @@
             "podsCreateAndDelete",
             "exec",
             "ingressCreateAndDelete",
-            "namespaceCreateAndDelete"
+            "namespaceCreateAndDelete",
+            "deploymentCreateAndDelete"
           ]
         }
       },

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -526,6 +526,13 @@
               "title": "namespaceCreateAndDelete",
               "type": "boolean"
             },
+            "deploymentCreateAndDelete": {
+              "default": true,
+              "description": "for deployment canary",
+              "required": [],
+              "title": "deploymentCreateAndDelete",
+              "type": "boolean"
+            },
             "podsCreateAndDelete": {
               "default": true,
               "description": "for pod and junit canaries",
@@ -563,7 +570,8 @@
             "podsCreateAndDelete",
             "exec",
             "ingressCreateAndDelete",
-            "namespaceCreateAndDelete"
+            "namespaceCreateAndDelete",
+            "deploymentCreateAndDelete"
           ],
           "title": "rbac"
         }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -430,6 +430,9 @@ serviceAccount:
     # -- for namespace canary
     namespaceCreateAndDelete: true
 
+    # -- for deployment canary
+    deploymentCreateAndDelete: true
+
     # @schema
     # required: false
     # default: []


### PR DESCRIPTION
## Description

This PR introduces RBAC permissions to allow the Canary Checker to create and delete Kubernetes deployments (see full allowance list below), as required for specific deployment-related tests. These changes support the `deploymentCreateAndDelete` setting in values.yaml.

Allowance list:
- get
- list
- watch
- create
- update
- patch
- delete

Solves https://github.com/flanksource/canary-checker/issues/2308