### PR TITLE
Allows volume mounts in JUnit checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,8 +234,8 @@ ginkgo:
 		CONTROLLER_GEN=$(GOBIN)/controller-gen
 
 .bin/yq: .bin
-	curl -sSLo $(YQ) https://github.com/mikefarah/yq/releases/download/v4.40.5/yq_$(OS)_$(ARCH) && \
-	chmod +x $(YQ)
+	curl -sSLo .bin/yq https://github.com/mikefarah/yq/releases/download/v4.40.5/yq_$(OS)_$(ARCH) && \
+	chmod +x .bin/yq
 
 
 .bin/go-junit-report: .bin

--- a/checks/junit.go
+++ b/checks/junit.go
@@ -105,16 +105,15 @@ func newPod(ctx *context.Context, check v1.JunitCheck) (*corev1.Pod, error) {
 				`, mountPath, mountPath),
 			},
 		}}
-	pod.Spec.Volumes = []corev1.Volume{
-		{
-			Name: volumeName,
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			},
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
-	}
+	})
 	pod.Spec.RestartPolicy = corev1.RestartPolicyNever
-	pod.Spec.InitContainers[0].VolumeMounts = []corev1.VolumeMount{{Name: volumeName, MountPath: filepath.Dir(check.TestResults)}}
+	//
+	pod.Spec.InitContainers[0].VolumeMounts = append(pod.Spec.InitContainers[0].VolumeMounts, corev1.VolumeMount{Name: volumeName, MountPath: filepath.Dir(check.TestResults)})
 	pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{Name: volumeName, MountPath: mountPath}}
 	return pod, nil
 }


### PR DESCRIPTION
This is to fix #2318.
Instead of initializing Volumes / VolumeMounts within the Junit check it only appends to the existing set of volume mounts (which may be empty in probably nearly all cases).