### PR TITLE
feat(s3): allow specifying storage class for PutObject

### DIFF
--- a/api/v1/checks.go
+++ b/api/v1/checks.go
@@ -123,7 +123,7 @@ type HTTPCheck struct {
 	Body string `yaml:"body,omitempty" json:"body,omitempty" template:"true"`
 	// Header fields to be used in the query
 	Headers []types.EnvVar `yaml:"headers,omitempty" json:"headers,omitempty"`
-	//Template the request body
+	// Template the request body
 	TemplateBody bool `yaml:"templateBody,omitempty" json:"templateBody,omitempty"`
 	// EnvVars are the environment variables that are accessible to templated body
 	EnvVars []types.EnvVar `yaml:"env,omitempty" json:"env,omitempty"`
@@ -187,6 +187,7 @@ type S3Check struct {
 	Relatable               `yaml:",inline" json:",inline"`
 	connection.S3Connection `yaml:",inline" json:",inline"`
 	BucketName              string `yaml:"bucketName" json:"bucketName,omitempty"`
+	StorageClass            string `yaml:"storageClass" json:"storageClass,omitempty"`
 }
 
 func (c S3Check) GetEndpoint() string {

--- a/checks/s3.go
+++ b/checks/s3.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flanksource/commons/utils"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/prometheus/client_golang/prometheus"
 
 	v1 "github.com/flanksource/canary-checker/api/v1"
@@ -93,9 +94,10 @@ func (c *S3Checker) Check(ctx *context.Context, check v1.S3Check) pkg.Results {
 	data := utils.RandomString(16)
 	updateTimer := NewTimer()
 	_, err = client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket: &check.BucketName,
-		Key:    &check.ObjectPath,
-		Body:   bytes.NewReader([]byte(data)),
+		Bucket:       &check.BucketName,
+		Key:          &check.ObjectPath,
+		Body:         bytes.NewReader([]byte(data)),
+		StorageClass: types.StorageClass(check.StorageClass),
 	})
 	if err != nil {
 		return results.Failf("Failed to put object %s in bucket %s: %v", check.ObjectPath, check.BucketName, err)

--- a/config/deploy/Canary.yml
+++ b/config/deploy/Canary.yml
@@ -7166,6 +7166,8 @@ spec:
                       skipTLSVerify:
                         description: Skip TLS verify when connecting to aws
                         type: boolean
+                      storageClass:
+                        type: string
                       transformDeleteStrategy:
                         type: string
                       usePathStyle:

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -7165,6 +7165,8 @@ spec:
                       skipTLSVerify:
                         description: Skip TLS verify when connecting to aws
                         type: boolean
+                      storageClass:
+                        type: string
                       transformDeleteStrategy:
                         type: string
                       usePathStyle:

--- a/config/schemas/canary.schema.json
+++ b/config/schemas/canary.schema.json
@@ -3740,6 +3740,9 @@
         },
         "bucketName": {
           "type": "string"
+        },
+        "storageClass": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/config/schemas/component.schema.json
+++ b/config/schemas/component.schema.json
@@ -4187,6 +4187,9 @@
         },
         "bucketName": {
           "type": "string"
+        },
+        "storageClass": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/config/schemas/health_s3.schema.json
+++ b/config/schemas/health_s3.schema.json
@@ -244,6 +244,9 @@
         },
         "bucketName": {
           "type": "string"
+        },
+        "storageClass": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/config/schemas/topology.schema.json
+++ b/config/schemas/topology.schema.json
@@ -4193,6 +4193,9 @@
         },
         "bucketName": {
           "type": "string"
+        },
+        "storageClass": {
+          "type": "string"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Allow configuring S3 check to use a non-default storage class for PutObject.
The storage class is specified as a raw string to allow for new values in the future as well as non-AWS custom storage classes.