### PR TITLE
fix: unable to define volumes via helm chart,

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
         - name: config
           configMap:
             name: {{ include "canary-checker.name" . }}
-        {{- with .Values.volumeMounts }}
+        {{- with .Values.volumes }}
           {{- toYaml . | nindent 8}}
         {{- end }}
       securityContext:


### PR DESCRIPTION
Tiny fix - without it all volumes ended up as `EmptyDir`, not defiled `ConfigMap` or `Secret`.

I was passing such values in Helm params
```yaml
# (...)
volumes:
- name: ca-cert
  secret:
    secretName: ca-cert
    items:
    - key: ca-cert.crt
      path: ca-cert.crt
- name: ca-cert-cfgmap
  configMap:
    name: ca-cert
    items:
    - key: "ca-cert.crt"
      path: "ca-cert.crt"
volumeMounts:
- name: ca-cert
  mountPath: "/etc/ssl/certs/root-ca.pem"
  subPath: ca-cert.crt
  readOnly: true
- name: ca-cert-cfgmap
  mountPath: "/etc/ssl/certs/root-ca-cfg.pem"
  subPath: ca-cert.crt
  readOnly: true
# (...)
```

Sadly all mounted files ended up as empty directories :| `kubectl describe pod canary-checker` (not a real cmd). Showed that volumes are always defined as `EmptyDir`.

In snippet check `Mounts` and `Volumes`. So in the end based on the config from `values` file for helm chart, it knew where to mount and what subpath but did not knew the definition of a volume.

```yaml
# (...)
      DEBUG:      true
      DB_URL:     embedded:///opt/database/
    Mounts:
      /app/canary-checker.properties from config (rw,path="canary-checker.properties")
      /etc/podinfo from podinfo (rw)
      /etc/ssl/certs/root-ca-cfg.pem from ca-cert-cfgmap (ro,path="ca-cert.crt")
      /etc/ssl/certs/root-ca.pem from ca-cert (ro,path="ca-cert.crt")
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-vhr8v (ro)
# (...)
Volumes:
  podinfo:
    Type:  DownwardAPI (a volume populated by information about the pod)
    Items:
      metadata.labels -> labels
  config:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      canary-checker
    Optional:  false
  ca-cert:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:
    SizeLimit:  <unset>
  ca-cert-cfgmap:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:
    SizeLimit:  <unset>
  kube-api-access-vhr8v:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
#(...)
```

AFTER the fix the same config and values looks like this - and this allows to mount Secrets/ConfigMaps as files, in my case the own Root CA for the organization.

```yaml
# (...)
      PING_MODE:  unprivileged
      DEBUG:      true
      DB_URL:     embedded:///opt/database/
    Mounts:
      /app/canary-checker.properties from config (rw,path="canary-checker.properties")
      /etc/podinfo from podinfo (rw)
      /etc/ssl/certs/root-ca-cfg.pem from ca-cert-cfg-root (ro,path="ca-cert.crt")
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-6fwmx (ro)
# (...)
Volumes:
  podinfo:
    Type:  DownwardAPI (a volume populated by information about the pod)
    Items:
      metadata.labels -> labels
  config:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      canary-checker
    Optional:  false
  ca-cert-cfg-root:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      root-ca-cert
    Optional:  false
  kube-api-access-6fwmx:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   Burstable
Node-Selectors:              <none>
# (...)
```
