### PR TITLE
feat:(sql) Add Timeout to sql check to cancel queries after timeout

### DIFF
--- a/api/v1/checks.go
+++ b/api/v1/checks.go
@@ -389,6 +389,7 @@ type SQLCheck struct {
 	Templatable `yaml:",inline" json:",inline"`
 	Relatable   `yaml:",inline" json:",inline"`
 	Connection  `yaml:",inline" json:",inline"`
+	Timeout     int    `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 	Query       string `yaml:"query" json:"query,omitempty" template:"true"`
 	// Number rows to check for
 	Result int `yaml:"results" json:"results,omitempty"`
@@ -399,6 +400,14 @@ func (c *SQLCheck) GetQuery() string {
 		return "SELECT 1"
 	}
 	return c.Query
+}
+
+func (c *SQLCheck) GetQueryTimeout() time.Duration {
+	if c.Timeout == 0 {
+		c.Timeout = 60
+	}
+
+	return time.Duration(c.Timeout) * time.Second
 }
 
 func (c SQLCheck) GetEndpoint() string {

--- a/checks/sql.go
+++ b/checks/sql.go
@@ -1,10 +1,12 @@
 package checks
 
 import (
+	gocontext "context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/flanksource/canary-checker/api/context"
 	"github.com/flanksource/canary-checker/api/external"
@@ -30,7 +32,7 @@ type SQLDetails struct {
 // Connects to a db using the specified `driver` and `connectionstring`
 // Performs the test query given in `query`.
 // Gives the single row test query result as result.
-func querySQL(driver string, connection string, query string) (SQLDetails, error) {
+func querySQL(driver string, connection string, query string, timout time.Duration) (SQLDetails, error) {
 	var result SQLDetails
 
 	if driver == mysqlCheckType {
@@ -44,8 +46,10 @@ func querySQL(driver string, connection string, query string) (SQLDetails, error
 		return result, fmt.Errorf("failed to connect to %s db: %w", driver, err)
 	}
 	defer db.Close()
+	ctx, cancel := gocontext.WithTimeout(gocontext.Background(), timout*time.Second)
+	defer cancel()
+	rows, err := db.QueryContext(ctx, query)
 
-	rows, err := db.Query(query)
 	if err != nil || rows.Err() != nil {
 		return result, fmt.Errorf("failed to query db: %w", err)
 	}
@@ -67,7 +71,7 @@ func querySQL(driver string, connection string, query string) (SQLDetails, error
 			return result, err
 		}
 
-		var row = make(map[string]interface{})
+		row := make(map[string]interface{})
 		for i, val := range rowValues {
 			if val == nil {
 				row[columns[i]] = nil
@@ -112,7 +116,7 @@ func querySQL(driver string, connection string, query string) (SQLDetails, error
 					row[columns[i]] = nil
 				}
 			case *types.JSON:
-				var jsonObj = make(map[string]any)
+				jsonObj := make(map[string]any)
 				var jsonArray []any
 				if err := json.Unmarshal(*v, &jsonObj); err == nil {
 					row[columns[i]] = jsonObj
@@ -155,6 +159,7 @@ func CheckSQL(ctx *context.Context, checker SQLChecker) pkg.Results { // nolint:
 	}
 
 	query := check.GetQuery()
+	timout := check.GetQueryTimeout()
 
 	if ctx.CanTemplate() {
 		query, err = template(ctx.WithCheck(checker.GetCheck()), v1.Template{
@@ -168,7 +173,7 @@ func CheckSQL(ctx *context.Context, checker SQLChecker) pkg.Results { // nolint:
 		}
 	}
 
-	details, err := querySQL(checker.GetDriver(), connection.URL, query)
+	details, err := querySQL(checker.GetDriver(), connection.URL, query, timout)
 	result.AddDetails(details)
 
 	if err != nil {

--- a/config/deploy/Canary.yml
+++ b/config/deploy/Canary.yml
@@ -6258,6 +6258,8 @@ spec:
                           template:
                             type: string
                         type: object
+                      timeout:
+                        type: integer
                       transform:
                         properties:
                           expr:
@@ -6435,6 +6437,8 @@ spec:
                           template:
                             type: string
                         type: object
+                      timeout:
+                        type: integer
                       transform:
                         properties:
                           expr:
@@ -6989,6 +6993,8 @@ spec:
                           template:
                             type: string
                         type: object
+                      timeout:
+                        type: integer
                       transform:
                         properties:
                           expr:

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -6257,6 +6257,8 @@ spec:
                           template:
                             type: string
                         type: object
+                      timeout:
+                        type: integer
                       transform:
                         properties:
                           expr:
@@ -6434,6 +6436,8 @@ spec:
                           template:
                             type: string
                         type: object
+                      timeout:
+                        type: integer
                       transform:
                         properties:
                           expr:
@@ -6988,6 +6992,8 @@ spec:
                           template:
                             type: string
                         type: object
+                      timeout:
+                        type: integer
                       transform:
                         properties:
                           expr:

--- a/config/schemas/canary.schema.json
+++ b/config/schemas/canary.schema.json
@@ -3040,6 +3040,9 @@
         "password": {
           "$ref": "#/$defs/EnvVar"
         },
+        "timeout": {
+          "type": "integer"
+        },
         "query": {
           "type": "string"
         },
@@ -3102,6 +3105,9 @@
         },
         "password": {
           "$ref": "#/$defs/EnvVar"
+        },
+        "timeout": {
+          "type": "integer"
         },
         "query": {
           "type": "string"
@@ -3582,6 +3588,9 @@
         },
         "password": {
           "$ref": "#/$defs/EnvVar"
+        },
+        "timeout": {
+          "type": "integer"
         },
         "query": {
           "type": "string"

--- a/config/schemas/component.schema.json
+++ b/config/schemas/component.schema.json
@@ -3385,6 +3385,9 @@
         "password": {
           "$ref": "#/$defs/EnvVar"
         },
+        "timeout": {
+          "type": "integer"
+        },
         "query": {
           "type": "string"
         },
@@ -3447,6 +3450,9 @@
         },
         "password": {
           "$ref": "#/$defs/EnvVar"
+        },
+        "timeout": {
+          "type": "integer"
         },
         "query": {
           "type": "string"
@@ -3945,6 +3951,9 @@
         },
         "password": {
           "$ref": "#/$defs/EnvVar"
+        },
+        "timeout": {
+          "type": "integer"
         },
         "query": {
           "type": "string"

--- a/config/schemas/health_mssql.schema.json
+++ b/config/schemas/health_mssql.schema.json
@@ -197,6 +197,9 @@
         "password": {
           "$ref": "#/$defs/EnvVar"
         },
+        "timeout": {
+          "type": "integer"
+        },
         "query": {
           "type": "string"
         },

--- a/config/schemas/health_mysql.schema.json
+++ b/config/schemas/health_mysql.schema.json
@@ -197,6 +197,9 @@
         "password": {
           "$ref": "#/$defs/EnvVar"
         },
+        "timeout": {
+          "type": "integer"
+        },
         "query": {
           "type": "string"
         },

--- a/config/schemas/health_postgres.schema.json
+++ b/config/schemas/health_postgres.schema.json
@@ -197,6 +197,9 @@
         "password": {
           "$ref": "#/$defs/EnvVar"
         },
+        "timeout": {
+          "type": "integer"
+        },
         "query": {
           "type": "string"
         },

--- a/config/schemas/topology.schema.json
+++ b/config/schemas/topology.schema.json
@@ -3391,6 +3391,9 @@
         "password": {
           "$ref": "#/$defs/EnvVar"
         },
+        "timeout": {
+          "type": "integer"
+        },
         "query": {
           "type": "string"
         },
@@ -3453,6 +3456,9 @@
         },
         "password": {
           "$ref": "#/$defs/EnvVar"
+        },
+        "timeout": {
+          "type": "integer"
         },
         "query": {
           "type": "string"
@@ -3951,6 +3957,9 @@
         },
         "password": {
           "$ref": "#/$defs/EnvVar"
+        },
+        "timeout": {
+          "type": "integer"
         },
         "query": {
           "type": "string"


### PR DESCRIPTION
This pull request introduces a new SQL check feature that allows users to define a timeout duration to cancel long-running queries. By default, the timeout is set to 1 minute.
