### PR TITLE
Adds flags to configure junit-results container image name and pull policy

### DIFF
--- a/checks/junit.go
+++ b/checks/junit.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/flanksource/canary-checker/api/context"
 	dutyKubernetes "github.com/flanksource/duty/kubernetes"
+	"github.com/spf13/pflag"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -26,11 +27,38 @@ func init() {
 	//register metrics here
 }
 
+// type alias to implement pflag.Value to allow setting in root.go
+type CorePullPolicy corev1.PullPolicy
+
+var _ pflag.Value = (*CorePullPolicy)(nil)
+var AllowedCorePullPolicyValues = []corev1.PullPolicy{corev1.PullAlways, corev1.PullIfNotPresent, corev1.PullNever}
+
+func (c *CorePullPolicy) Set(s string) error {
+	for _, allowed := range AllowedCorePullPolicyValues {
+		if s == string(allowed) {
+			*c = CorePullPolicy(s)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("PullPolicy '%s' not one of allowed values: %v", s, AllowedCorePullPolicyValues)
+}
+
+func (c *CorePullPolicy) String() string {
+	return string(*c)
+}
+
+func (c *CorePullPolicy) Type() string {
+	return "CorePullPolicy"
+}
+
+var JunitContainerImageName string
+var JunitContainerImagePullPolicy CorePullPolicy = CorePullPolicy(corev1.PullIfNotPresent)
+
 const (
 	volumeName           = "junit-results"
 	mountPath            = "/tmp/junit-results"
 	containerName        = "junit-results"
-	containerImage       = "ubuntu"
 	podKind              = "Pod"
 	junitCheckSelector   = "canary-checker.flanksource.com/check"
 	junitCheckLabelValue = "junit-check"
@@ -83,8 +111,9 @@ func newPod(ctx *context.Context, check v1.JunitCheck) (*corev1.Pod, error) {
 	}
 	pod.Spec.Containers = []corev1.Container{
 		{
-			Name:  containerName,
-			Image: containerImage,
+			Name:            containerName,
+			ImagePullPolicy: corev1.PullPolicy(JunitContainerImagePullPolicy),
+			Image:           JunitContainerImageName,
 			Args: []string{
 				"bash",
 				"-c",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -230,6 +230,17 @@ func ServerFlags(flags *pflag.FlagSet) {
 		os.Getenv("UPSTREAM_INSECURE_SKIP_VERIFY") == "true",
 		"Skip TLS verification on the upstream servers certificate",
 	)
+	flags.StringVar(
+		&checks.JunitContainerImageName,
+		"junit-results-container-image-name",
+		"ubuntu:latest",
+		"Sets the container image name for the junit results container sidecar",
+	)
+	flags.Var(
+		&checks.JunitContainerImagePullPolicy,
+		"junit-results-container-image-pull-policy",
+		fmt.Sprintf("Sets the junit results container sidecar pull policy. Allowed values: %v", checks.AllowedCorePullPolicyValues),
+	)
 
 	duty.BindPFlags(flags, duty.SkipMigrationByDefaultMode)
 


### PR DESCRIPTION
This addresses https://github.com/flanksource/canary-checker/issues/2651

The issue with the current approach was, that the junit-results image was using `ubuntu` as an image, which also infers it being `latest`.

`latest` will by default always use an `ImagePullPolicy` of `Always` in k8s, thus docker hubs rate limits may eventually be hit.

This adds two flags to the operator to allow overriding the junit results container image name and its pull policy:

```
      --junit-results-container-image-name string                          Sets the container image name for the junit container sidecar (default "ubuntu:latest")
      --junit-results-container-image-pull-policy CorePullPolicy   Sets the junit container sidecar pull policy. Allowed values: [Always IfNotPresent Never] (default IfNotPresent)
```
I have chosen to make IfNotPresent the default for the pull-policy as it seems unnecessary to check the image for updates on every junit run since we actually only ever run `bash` in the container.

We've tested this in our own canary-checker setup and it works as expected.