### PR TITLE
fix: last run time parsing

### DIFF
--- a/pkg/api.go
+++ b/pkg/api.go
@@ -64,7 +64,7 @@ type CheckStatus struct {
 }
 
 func (s CheckStatus) GetTime() (time.Time, error) {
-	return time.Parse("2006-01-02 15:04:05", s.Time)
+	return time.Parse(time.RFC3339, s.Time)
 }
 
 type Canary struct {


### PR DESCRIPTION
Fixes: https://github.com/flanksource/canary-checker/issues/2770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time parsing to support RFC3339 standard format for enhanced compatibility and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->