### PR TITLE
chore: add fixture for kubernetes ingress to http checks

### DIFF
--- a/fixtures/k8s/kubernetes-ingress-to-http-checks.yaml
+++ b/fixtures/k8s/kubernetes-ingress-to-http-checks.yaml
@@ -1,0 +1,26 @@
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: ingress-canary
+spec:
+  schedule: "@every 5m"
+  kubernetes:
+    - name: ingress-http-checks
+      kind: Ingress
+      namespaceSelector:
+        name: "*"
+      transform:
+        expr: |
+          {
+            'name': 'ingress-http-checks',
+            'namespace': 'default',
+            'spec': {
+              'schedule': '@every 5m',
+              'http': dyn(results).map(r,
+                r.Object.spec.?rules.orValue([]).map(rule, {
+                  'name': r.Object.metadata.namespace + '/' + r.Object.metadata.name + '/' + rule.host,
+                  'url': (r.Object.spec.?tls.orValue([]).exists(t, rule.host in t.hosts) ? 'https://' : 'http://') + rule.host
+                })
+              ).flatten()
+            }
+          }.toJSON()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a Kubernetes canary configuration fixture for ingress HTTP checks. The fixture includes scheduled evaluation and transformation logic to aggregate ingress data into structured JSON payloads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->