### PR TITLE
fix(pkg/jobs): use error message in events

### DIFF
--- a/pkg/jobs/canary/status.go
+++ b/pkg/jobs/canary/status.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flanksource/canary-checker/pkg/utils"
 	"github.com/flanksource/duty/context"
 	dutyTypes "github.com/flanksource/duty/types"
+	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -90,7 +91,7 @@ func UpdateCanaryStatusAndEvent(ctx context.Context, canary v1.Canary, results [
 		if result.Pass {
 			status = v1.Passed
 		} else {
-			failEvents = append(failEvents, fmt.Sprintf("%s-%s: %s", result.Check.GetType(), result.Check.GetEndpoint(), result.Message))
+			failEvents = append(failEvents, fmt.Sprintf("%s-%s: %s", result.Check.GetType(), result.Check.GetEndpoint(), lo.CoalesceOrEmpty(result.Message, pkg.TruncateMessage(result.Error))))
 			status = v1.Failed
 		}
 


### PR DESCRIPTION
Previous behavior of events did not properly show event information.

```
Events:
  Type     Reason  Age                   From            Message
  ----     ------  ----                  ----            -------
  Warning  Failed  37s (x29 over 5m39s)  canary-checker  s3-https://mys3.com/mycanary:
```

With proposed change, the event will match the error message from the canary's status.

```
Events:
  Type     Reason  Age                   From            Message
  ----     ------  ----                  ----            -------
  Warning  Failed  37s (x29 over 5m39s)  canary-checker  s3-https://mys3.com/mycanary: failed to populate aws connection: could not get AWS access key id from env var: could not find secret myns/mysecret: secrets "mysecret" not found
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Canary failure events now show a more informative message: use the check's message when available, otherwise fall back to a truncated error so failures display clearer error details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->