### PR TITLE
feat(http): add maxRedirects support for HTTP checks

### DIFF
--- a/api/v1/checks.go
+++ b/api/v1/checks.go
@@ -125,6 +125,9 @@ type HTTPCheck struct {
 	ThresholdMillis int `yaml:"thresholdMillis,omitempty" json:"thresholdMillis,omitempty"`
 	// Expected response codes for the HTTP Request.
 	ResponseCodes []int `yaml:"responseCodes,omitempty" json:"responseCodes,omitempty"`
+	// Maximum redirects to follow (Defaults 10).
+	// Set to 0 to disable following redirects.
+	MaxRedirects *int `yaml:"maxRedirects,omitempty" json:"maxRedirects,omitempty"`
 	// Exact response content expected to be returned by the endpoint.
 	ResponseContent string `yaml:"responseContent,omitempty" json:"responseContent,omitempty"`
 	// Deprecated, use expr and jsonpath function

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -2015,6 +2015,11 @@ func (in *HTTPCheck) DeepCopyInto(out *HTTPCheck) {
 		*out = make([]int, len(*in))
 		copy(*out, *in)
 	}
+	if in.MaxRedirects != nil {
+		in, out := &in.MaxRedirects, &out.MaxRedirects
+		*out = new(int)
+		**out = **in
+	}
 	if in.ResponseJSONContent != nil {
 		in, out := &in.ResponseJSONContent, &out.ResponseJSONContent
 		*out = new(JSONCheck)

--- a/checks/http.go
+++ b/checks/http.go
@@ -33,7 +33,11 @@ import (
 	"github.com/flanksource/canary-checker/pkg/utils"
 )
 
-const trueString = "true"
+const (
+	trueString = "true"
+
+	maxRedirectDefault = 10 // default for the http lib we're using. But we enforce it explicitly.
+)
 
 var (
 	responseStatus = prometheus.NewCounterVec(
@@ -142,6 +146,12 @@ func (c *HTTPChecker) generateHTTPRequest(ctx *context.Context, check v1.HTTPChe
 	if check.ThresholdMillis > 0 {
 		client.Timeout(time.Duration(check.ThresholdMillis) * time.Millisecond)
 	}
+	if check.MaxRedirects != nil {
+		client.RedirectPolicy(*check.MaxRedirects)
+	} else {
+		client.RedirectPolicy(maxRedirectDefault)
+	}
+
 	if ctx.HARCollector != nil {
 		client.HARCollector(ctx.HARCollector)
 	}

--- a/config/deploy/Canary.yml
+++ b/config/deploy/Canary.yml
@@ -3722,6 +3722,11 @@ spec:
                       markFailOnEmpty:
                         description: If check or transformation returns empty, that should be marked as failed
                         type: boolean
+                      maxRedirects:
+                        description: |-
+                          Maximum redirects to follow (Defaults 10).
+                          Set to 0 to disable following redirects.
+                        type: integer
                       maxSSLExpiry:
                         description: Maximum number of days until the SSL Certificate expires.
                         type: integer

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -3721,6 +3721,11 @@ spec:
                       markFailOnEmpty:
                         description: If check or transformation returns empty, that should be marked as failed
                         type: boolean
+                      maxRedirects:
+                        description: |-
+                          Maximum redirects to follow (Defaults 10).
+                          Set to 0 to disable following redirects.
+                        type: integer
                       maxSSLExpiry:
                         description: Maximum number of days until the SSL Certificate expires.
                         type: integer

--- a/config/schemas/canary.schema.json
+++ b/config/schemas/canary.schema.json
@@ -2485,6 +2485,10 @@
           "type": "array",
           "description": "Expected response codes for the HTTP Request."
         },
+        "maxRedirects": {
+          "type": "integer",
+          "description": "Maximum redirects to follow (Defaults 10).\nSet to 0 to disable following redirects."
+        },
         "responseContent": {
           "type": "string",
           "description": "Exact response content expected to be returned by the endpoint."

--- a/config/schemas/component.schema.json
+++ b/config/schemas/component.schema.json
@@ -2775,6 +2775,10 @@
           "type": "array",
           "description": "Expected response codes for the HTTP Request."
         },
+        "maxRedirects": {
+          "type": "integer",
+          "description": "Maximum redirects to follow (Defaults 10).\nSet to 0 to disable following redirects."
+        },
         "responseContent": {
           "type": "string",
           "description": "Exact response content expected to be returned by the endpoint."

--- a/config/schemas/health_http.schema.json
+++ b/config/schemas/health_http.schema.json
@@ -246,6 +246,10 @@
           "type": "array",
           "description": "Expected response codes for the HTTP Request."
         },
+        "maxRedirects": {
+          "type": "integer",
+          "description": "Maximum redirects to follow (Defaults 10).\nSet to 0 to disable following redirects."
+        },
         "responseContent": {
           "type": "string",
           "description": "Exact response content expected to be returned by the endpoint."

--- a/config/schemas/topology.schema.json
+++ b/config/schemas/topology.schema.json
@@ -2745,6 +2745,10 @@
           "type": "array",
           "description": "Expected response codes for the HTTP Request."
         },
+        "maxRedirects": {
+          "type": "integer",
+          "description": "Maximum redirects to follow (Defaults 10).\nSet to 0 to disable following redirects."
+        },
         "responseContent": {
           "type": "string",
           "description": "Exact response content expected to be returned by the endpoint."

--- a/fixtures/minimal/http_redirect_no_follow.yaml
+++ b/fixtures/minimal/http_redirect_no_follow.yaml
@@ -1,0 +1,17 @@
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: http-redirect-no-follow
+  labels:
+    canary: http
+spec:
+  schedule: "@every 5m"
+  http:
+    - name: redirect-301-no-follow
+      url: "https://httpbin.flanksource.com/redirect-to?url=/get&status_code=301"
+      maxRedirects: 0
+      responseCodes: [301]
+      test:
+        expr: "headers['Location'] == '/get'"
+      display:
+        expr: "'status=' + string(code) + ', location=' + headers['Location']"

--- a/fixtures/minimal/kustomization.yaml
+++ b/fixtures/minimal/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - http_single_pass.yaml
   - http_timeout_fail.yaml
   - http_auth_static_pass.yaml
+  - http_redirect_no_follow.yaml
   - display-with-cel_pass.yaml
   - display-with-gotemplate_pass.yaml
   - display-with-javascript_pass.yaml


### PR DESCRIPTION
resolves: https://github.com/flanksource/canary-checker/issues/2893