### PR TITLE
chore: update release steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-    uses: flanksource/action-workflows/.github/workflows/create-draft-release.yml@e22094854bc7759abafb4ee49cb5585a5ccf91b0 # main
-    with:
-      pre_release: ${{ github.event_name != 'workflow_dispatch' || inputs.channel != 'stable' }}
+    uses: flanksource/action-workflows/.github/workflows/create-draft-release.yml@fdb5214bd746d02ef0a8b2f80d2e62731e34fca1
 
   binary-linux:
     runs-on: ubuntu-latest

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -58,6 +58,7 @@ module.exports = {
     [
       '@semantic-release/github',
       {
+        draftRelease: true,
         // From: https://github.com/semantic-release/github/pull/487#issuecomment-1486298997
         successComment: false,
         failTitle: false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflow now creates releases as drafts instead of publishing them immediately, enabling review before public availability.
  * Semantic-release GitHub plugin configuration updated to enable draft release mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->