### PR TITLE
fix: reject duplicate check names in dependency sorting

### DIFF
--- a/checks/runchecks.go
+++ b/checks/runchecks.go
@@ -97,6 +97,9 @@ func sortChecksByDependency(checks []external.Check) ([]external.Check, error) {
 		if name == "" {
 			continue
 		}
+		if _, exists := checkMap[name]; exists {
+			return nil, fmt.Errorf("duplicate check name '%s'", name)
+		}
 		checkMap[name] = check
 	}
 

--- a/checks/runchecks_test.go
+++ b/checks/runchecks_test.go
@@ -83,6 +83,16 @@ func TestSortChecksByDependency(t *testing.T) {
 			wantErr:     true,
 			errContains: "must have a name",
 		},
+		{
+			name: "duplicate check names should error",
+			checks: []external.Check{
+				v1.HTTPCheck{Description: v1.Description{Name: "a"}},
+				v1.HTTPCheck{Description: v1.Description{Name: "a"}},
+				v1.HTTPCheck{Description: v1.Description{Name: "b", DependsOn: []string{"a"}}},
+			},
+			wantErr:     true,
+			errContains: "duplicate check name 'a'",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes a small edge case in `dependsOn` sorting: duplicate check names used to overwrite the earlier entry in `checkMap`, so dependency resolution could silently point at the last one. Tiny bug, kinda nasty.

Related: #2802

Repro:
1. Add the duplicate-name case in `TestSortChecksByDependency`
2. Run `go test ./checks -run TestSortChecksByDependency -count=1`
3. Before: `expected error containing "duplicate check name 'a'", got nil`

Now duplicate names return a clear error before sorting starts.

Tested:
`go test ./checks -run TestSortChecksByDependency -count=1`
`go test ./checks -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now detects and reports duplicate check names as errors instead of silently overwriting them, providing clear diagnostic messages for configuration conflicts.

* **Tests**
  * Added test case verifying duplicate check name detection and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->