### PR TITLE
fix: check failed metric double count

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -272,19 +272,25 @@ func Record(
 			}
 		}
 	} else {
-		fail.Append(1)
 		Gauge.WithLabelValues(gaugeLabels...).Set(1)
-
 		CanaryCheckInfo.WithLabelValues(checkMetricLabels...).Set(1)
 
 		// The success / invalid / error / failed counters are mutually
 		// exclusive: a single check run increments exactly one of them.
+		//
+		// Only genuine failures append to the fail window (and thus the
+		// in-memory Uptime1H). Invalid configs and internal/DB errors are not
+		// the monitored target's downtime, so they drop out of the uptime
+		// ratio entirely. This keeps the in-memory uptime in agreement with
+		// the Prometheus uptime, which is computed from canary_check_failed_count
+		// and canary_check_success_count only.
 		switch {
 		case result.Invalid:
 			OpsInvalidCount.WithLabelValues(checkMetricLabels...).Inc()
 		case result.InternalError:
 			OpsErrorCount.WithLabelValues(checkMetricLabels...).Inc()
 		default:
+			fail.Append(1)
 			OpsFailedCount.WithLabelValues(checkMetricLabels...).Inc()
 		}
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -272,21 +272,19 @@ func Record(
 			}
 		}
 	} else {
-		if result.Invalid {
-			OpsInvalidCount.WithLabelValues(checkMetricLabels...).Inc()
-		} else {
-			OpsFailedCount.WithLabelValues(checkMetricLabels...).Inc()
-		}
-
 		fail.Append(1)
 		Gauge.WithLabelValues(gaugeLabels...).Set(1)
 
 		CanaryCheckInfo.WithLabelValues(checkMetricLabels...).Set(1)
 
-		if result.InternalError {
+		// The success / invalid / error / failed counters are mutually
+		// exclusive: a single check run increments exactly one of them.
+		switch {
+		case result.Invalid:
+			OpsInvalidCount.WithLabelValues(checkMetricLabels...).Inc()
+		case result.InternalError:
 			OpsErrorCount.WithLabelValues(checkMetricLabels...).Inc()
-		} else {
-			fail.Append(1)
+		default:
 			OpsFailedCount.WithLabelValues(checkMetricLabels...).Inc()
 		}
 	}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,161 @@
+package metrics
+
+import (
+	"sync"
+	"testing"
+
+	v1 "github.com/flanksource/canary-checker/api/v1"
+	"github.com/flanksource/canary-checker/pkg"
+	dutycontext "github.com/flanksource/duty/context"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+var setupOnce sync.Once
+
+func ensureMetricsSetup() {
+	setupOnce.Do(func() {
+		SetupMetrics()
+	})
+}
+
+// checkMetricLabelsFor mirrors the label slice Record() builds for the
+// check-scoped counters (OpsCount, OpsFailedCount, OpsSuccessCount,
+// OpsErrorCount, CanaryCheckInfo) when no additional metric labels are
+// configured.
+func checkMetricLabelsFor(canary v1.Canary, check pkg.GenericCheck) []string {
+	return []string{
+		check.GetType(),
+		canary.GetDescription(check),
+		canary.Name,
+		canary.Namespace,
+		canary.Spec.Owner,
+		canary.Spec.Severity,
+		canary.GetCheckID(check.GetName()),
+		check.GetName(),
+	}
+}
+
+func newFixture(checkName, checkKey string) (v1.Canary, pkg.GenericCheck) {
+	canary := v1.Canary{}
+	canary.Name = "test-canary"
+	canary.Namespace = "test-ns"
+	canary.Status.Checks = map[string]string{checkName: checkKey}
+
+	check := pkg.GenericCheck{
+		Type:     "http",
+		Endpoint: "http://example.com",
+	}
+	check.Name = checkName
+	return canary, check
+}
+
+func resultFor(canary v1.Canary, check pkg.GenericCheck, pass, invalid, internalErr bool) *pkg.CheckResult {
+	return &pkg.CheckResult{
+		Pass:          pass,
+		Invalid:       invalid,
+		InternalError: internalErr,
+		Duration:      10,
+		Check:         check,
+		Canary:        canary,
+	}
+}
+
+// TestRecord_FailedCountNotDoubleRecorded asserts that a single check run
+// increments the outcome counters exactly once and appends to the rolling
+// uptime window exactly once.
+//
+// It also pins the uptime-ratio semantics: only genuine failures append to the
+// fail window and only passes append to the pass window. Invalid and
+// internal-error results drop out of the ratio entirely (neither pass nor
+// fail), so the in-memory Uptime1H agrees with the Prometheus uptime, which is
+// computed from canary_check_failed_count + canary_check_success_count only.
+//
+// Regression test for the double-count bug where canary_check_failed_count was
+// incremented twice (and fail.Append called twice) for a normal failure.
+func TestRecord_FailedCountNotDoubleRecorded(t *testing.T) {
+	ensureMetricsSetup()
+	ctx := dutycontext.New()
+
+	cases := []struct {
+		name             string
+		pass             bool
+		invalid          bool
+		internalErr      bool
+		wantFailedDelta  float64
+		wantInvalidDelta float64
+		wantErrorDelta   float64
+		wantSuccessDelta float64
+		wantUptimeFailed int
+		wantUptimePassed int
+	}{
+		{
+			name:             "normal failure",
+			pass:             false,
+			wantFailedDelta:  1,
+			wantUptimeFailed: 1,
+		},
+		{
+			name:             "invalid failure",
+			pass:             false,
+			invalid:          true,
+			wantInvalidDelta: 1,
+			// invalid results drop out of the uptime ratio: neither pass nor fail.
+			wantUptimeFailed: 0,
+			wantUptimePassed: 0,
+		},
+		{
+			name:           "internal error failure",
+			pass:           false,
+			internalErr:    true,
+			wantErrorDelta: 1,
+			// internal errors drop out of the uptime ratio: neither pass nor fail.
+			wantUptimeFailed: 0,
+			wantUptimePassed: 0,
+		},
+		{
+			name:             "pass",
+			pass:             true,
+			wantSuccessDelta: 1,
+			wantUptimePassed: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			canary, check := newFixture(tc.name, tc.name)
+			labels := checkMetricLabelsFor(canary, check)
+
+			// The failed/passed rolling windows are global and keyed by check
+			// key, so reset this case's key after it runs. Otherwise uptime
+			// counts accumulate across `go test -count=N` runs.
+			t.Cleanup(func() { RemoveCheckByKey(canary.GetCheckID(check.GetName())) })
+
+			beforeFailed := testutil.ToFloat64(OpsFailedCount.WithLabelValues(labels...))
+			beforeInvalid := testutil.ToFloat64(OpsInvalidCount.WithLabelValues(labels...))
+			beforeError := testutil.ToFloat64(OpsErrorCount.WithLabelValues(labels...))
+			beforeSuccess := testutil.ToFloat64(OpsSuccessCount.WithLabelValues(labels...))
+
+			uptime, _ := Record(ctx, canary, resultFor(canary, check, tc.pass, tc.invalid, tc.internalErr))
+
+			if got := testutil.ToFloat64(OpsFailedCount.WithLabelValues(labels...)) - beforeFailed; got != tc.wantFailedDelta {
+				t.Errorf("canary_check_failed_count delta = %v, want %v", got, tc.wantFailedDelta)
+			}
+			if got := testutil.ToFloat64(OpsInvalidCount.WithLabelValues(labels...)) - beforeInvalid; got != tc.wantInvalidDelta {
+				t.Errorf("canary_check_invalid_count delta = %v, want %v", got, tc.wantInvalidDelta)
+			}
+			if got := testutil.ToFloat64(OpsErrorCount.WithLabelValues(labels...)) - beforeError; got != tc.wantErrorDelta {
+				t.Errorf("canary_check_error_count delta = %v, want %v", got, tc.wantErrorDelta)
+			}
+			if got := testutil.ToFloat64(OpsSuccessCount.WithLabelValues(labels...)) - beforeSuccess; got != tc.wantSuccessDelta {
+				t.Errorf("canary_check_success_count delta = %v, want %v", got, tc.wantSuccessDelta)
+			}
+
+			if uptime.Failed != tc.wantUptimeFailed {
+				t.Errorf("uptime.Failed = %v, want %v", uptime.Failed, tc.wantUptimeFailed)
+			}
+			if uptime.Passed != tc.wantUptimePassed {
+				t.Errorf("uptime.Passed = %v, want %v", uptime.Passed, tc.wantUptimePassed)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Metrics now accurately categorize failure types as distinct categories: invalid results, internal errors, and genuine failures are tracked separately
  * Improved uptime calculation by excluding invalid and error results, now only counting genuine failures toward downtime

* **Tests**
  * Added regression test for failure metric recording to ensure accurate categorization and uptime tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->