### PR TITLE
fix(prometheus): GetUptime PromQL formula had operator precedence bug and nil/NaN panics

### DIFF
--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -33,11 +33,22 @@ func (p PrometheusClient) GetHistogramQuantileLatency(percentile, checkKey, dura
 func (p PrometheusClient) GetUptime(checkKey, duration string) (float64, error) {
 	success := fmt.Sprintf("rate(canary_check_success_count{key='%v'}[%v])", checkKey, duration)
 	failed := fmt.Sprintf("rate(canary_check_failed_count{key='%v'}[%v])", checkKey, duration)
-	uptime, _, err := p.Query(context.TODO(), fmt.Sprintf("%s/%s + %s", failed, failed, success), time.Now())
+	result, _, err := p.Query(context.TODO(), fmt.Sprintf("(%s / (%s + %s)) * 100", success, failed, success), time.Now())
 	if err != nil {
 		return 0, err
 	}
-	return 100 - float64(uptime.(model.Vector)[0].Value), nil
+	if result == nil {
+		return 0, nil
+	}
+	vec, ok := result.(model.Vector)
+	if !ok || len(vec) == 0 {
+		return 0, nil
+	}
+	val := float64(vec[0].Value)
+	if val != val { // NaN check
+		return 0, nil
+	}
+	return val, nil
 }
 
 func NewPrometheusAPI(ctx dutyContext.Context, conn connection.PrometheusConnection) (*PrometheusClient, error) {


### PR DESCRIPTION
Closes #2989.

The PromQL query `failed/failed + success` was parsed as `(failed/failed) + success = 1 + success`, making uptime return a spurious rate rather than a useful percentage.

Root cause: missing parentheses around the denominator, and no *100 multiplier. Fix: `(success / (failed + success)) * 100` to produce a 0–100 uptime percentage.

Additionally, the result was accessed via `model.Vector[0]` without nil, empty-vector, or NaN guards, causing a panic when no samples exist in the rate window. Added guards for all three.