### PR TITLE
fix(metrics): include additional check metric labels in canary_check_invalid_count

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -62,7 +62,7 @@ func SetupMetrics() {
 			Name: "canary_check_invalid_count",
 			Help: "The total number of invalid checks",
 		},
-		[]string{"type", "endpoint", "canary_name", "canary_namespace", "owner", "severity", "key", "name"},
+		checkLabels,
 	)
 
 	CanaryCheckInfo = prometheus.NewGaugeVec(


### PR DESCRIPTION
When --metric-labels-allowlist is configured, OpsInvalidCount was registered with only the base 8 labels while Record() called it with checkMetricLabels that include the additional labels. This caused Prometheus label mismatch panics which were silently swallowed by recover(), resulting in invalid check metrics not being recorded.

Switched OpsInvalidCount to use checkLabels (which appends AdditionalCheckMetricLabels), matching all other counters that already use it.

Fixes #2990