### PR TITLE
fix: remove dead "&& false" disabling duration clamp in CheckStatusFromResult

### DIFF
--- a/pkg/api.go
+++ b/pkg/api.go
@@ -224,7 +224,7 @@ func CheckStatusFromResult(result CheckResult) CheckStatus {
 	}
 
 	// For check duration over ~25 days, we limit it to MaxInt32 milliseconds.
-	if result.Duration > math.MaxInt32 && false {
+	if result.Duration > math.MaxInt32 {
 		cs.DurationMs = math.MaxInt32
 	} else {
 		cs.DurationMs = int32(result.Duration)


### PR DESCRIPTION
closes: https://github.com/flanksource/canary-checker/issues/2993

The `CheckStatusFromResult` function has a guard to clamp check durations exceeding `math.MaxInt32` milliseconds (~25 days) to prevent overflow when casting to `int32`. A leftover `&& false` short-circuits the condition, so the clamp never runs and long-running checks produce wrapped `DurationMs` values.

Remove the dead boolean so the clamp works as intended.