### PR TITLE
fix(metrics): canary_check gauge uses allowlisted label names instead of values

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -241,7 +241,7 @@ func Record(
 		latency.Append(float64(result.Duration))
 	}
 
-	gaugeLabels := append([]string{key, checkType, canaryName, canaryNamespace, name}, v1.AdditionalCheckMetricLabels...)
+	gaugeLabels := append([]string{key, checkType, canaryName, canaryNamespace, name}, additionalLabels...)
 
 	if result.Pass {
 		pass.Append(1)


### PR DESCRIPTION
Fixes #2991

When `--metric-labels-allowlist` is configured, the `canary_check` Gauge appended the allowlisted label keys (e.g. "env", "region") as label values instead of resolving them from the check result's actual labels.

All other canary check metrics (`OpsCount`, `RequestLatency`, `CanaryCheckInfo`, etc.) already resolved these labels correctly via `result.Check.GetLabels()`.

**Fix:** use `additionalLabels` (already resolved values) instead of `v1.AdditionalCheckMetricLabels` (the raw key names) when building the Gauge's label values.