### PR TITLE
fix(crd): show Schedule instead of deprecated Interval in canary printer column

### DIFF
--- a/api/v1/canary_types.go
+++ b/api/v1/canary_types.go
@@ -502,7 +502,7 @@ type CheckStatus struct {
 
 // Canary is the Schema for the canaries API
 // +kubebuilder:printcolumn:name="Replicas",type=integer,priority=1,JSONPath=`.spec.replicas`
-// +kubebuilder:printcolumn:name="Interval",type=string,JSONPath=`.spec.interval`
+// +kubebuilder:printcolumn:name="Schedule",type=string,JSONPath=`.spec.schedule`
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.status`
 // +kubebuilder:printcolumn:name="Last Check",type=date,JSONPath=`.status.lastCheck`
 // +kubebuilder:printcolumn:name="Uptime 1H",type=string,JSONPath=`.status.uptime1h`

--- a/config/deploy/Canary.yml
+++ b/config/deploy/Canary.yml
@@ -19,8 +19,8 @@ spec:
           name: Replicas
           priority: 1
           type: integer
-        - jsonPath: .spec.interval
-          name: Interval
+        - jsonPath: .spec.schedule
+          name: Schedule
           type: string
         - jsonPath: .status.status
           name: Status

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -18,8 +18,8 @@ spec:
           name: Replicas
           priority: 1
           type: integer
-        - jsonPath: .spec.interval
-          name: Interval
+        - jsonPath: .spec.schedule
+          name: Schedule
           type: string
         - jsonPath: .status.status
           name: Status


### PR DESCRIPTION
The `INTERVAL` column in `kubectl get canaries` was always empty. Its print-column JSONPath pointed at `.spec.interval`, a field deprecated in Aug 2021 (commit a59e6d09) in favor of `.spec.schedule`. Canaries are authored with `schedule`, so `.spec.interval` is unset and the column rendered blank.

Point the printer column at `.spec.schedule` and rename it to `Schedule`. Regenerate the CRD manifests (`config/deploy/Canary.yml`, `config/deploy/manifests.yaml`).

Fixes #2999