### PR TITLE
fix: lastTransitionedTime never populated due to self-comparison

### DIFF
--- a/pkg/api/run_now.go
+++ b/pkg/api/run_now.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/flanksource/canary-checker/api/context"
 	v1 "github.com/flanksource/canary-checker/api/v1"
@@ -58,6 +59,10 @@ func RunCanaryHandler(c echo.Context) error {
 		return nil
 	}
 
+	// Capture the cutoff before persisting so LatestCheckStatus excludes the
+	// current run's just-saved status and compares against the prior state.
+	now := time.Now()
+
 	for _, result := range results {
 		if _, err := cache.PostgresCache.Add(ctx.Context, pkg.FromV1(result.Canary, result.Check), pkg.CheckStatusFromResult(*result)); err != nil {
 			return errorResponse(c, err, http.StatusInternalServerError)
@@ -68,7 +73,7 @@ func RunCanaryHandler(c echo.Context) error {
 		}
 	}
 
-	canaryJobs.UpdateCanaryStatusAndEvent(ctx.Context, *canary, results)
+	canaryJobs.UpdateCanaryStatusAndEvent(ctx.Context, *canary, results, now)
 	return c.JSON(http.StatusOK, results[0])
 }
 

--- a/pkg/db/canary.go
+++ b/pkg/db/canary.go
@@ -184,14 +184,23 @@ func LatestCheckStatus(ctx context.Context, checkID string, before time.Time) (*
 		return nil, nil
 	}
 	var status models.CheckStatus
-	if err := ctx.DB().Limit(1).Select("time, created_at, status").
+	// Note: GORM's Find does not return ErrRecordNotFound when no rows match
+	// (only First/Take/Last do) — it leaves the destination zero-valued and
+	// returns a non-nil pointer. Check RowsAffected so the first run, which has
+	// no prior check_statuses row, yields nil instead of a zero-value struct
+	// (which would otherwise set LastTransitionedTime to 0001-01-01).
+	res := ctx.DB().Limit(1).Select("time, created_at, status").
 		Where("check_id = ? AND time < ?", checkID, before.UTC().Format(time.RFC3339)).
-		Order("time DESC").Find(&status).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
+		Order("time DESC").Find(&status)
+	if res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 
-		return nil, err
+		return nil, res.Error
+	}
+	if res.RowsAffected == 0 {
+		return nil, nil
 	}
 
 	return &status, nil

--- a/pkg/db/canary.go
+++ b/pkg/db/canary.go
@@ -184,23 +184,15 @@ func LatestCheckStatus(ctx context.Context, checkID string, before time.Time) (*
 		return nil, nil
 	}
 	var status models.CheckStatus
-	// Note: GORM's Find does not return ErrRecordNotFound when no rows match
-	// (only First/Take/Last do) — it leaves the destination zero-valued and
-	// returns a non-nil pointer. Check RowsAffected so the first run, which has
-	// no prior check_statuses row, yields nil instead of a zero-value struct
-	// (which would otherwise set LastTransitionedTime to 0001-01-01).
-	res := ctx.DB().Limit(1).Select("time, created_at, status").
+	err := ctx.DB().Select("time, created_at, status").
 		Where("check_id = ? AND time < ?", checkID, before.UTC().Format(time.RFC3339)).
-		Order("time DESC").Find(&status)
-	if res.Error != nil {
-		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+		Order("time DESC").Take(&status).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 
-		return nil, res.Error
-	}
-	if res.RowsAffected == 0 {
-		return nil, nil
+		return nil, err
 	}
 
 	return &status, nil

--- a/pkg/db/canary.go
+++ b/pkg/db/canary.go
@@ -174,12 +174,19 @@ func GetTransformedCheckIDs(ctx context.Context, canaryID string, excludeTypes .
 	return ids, err
 }
 
-func LatestCheckStatus(ctx context.Context, checkID string) (*models.CheckStatus, error) {
+// LatestCheckStatus returns the most recent check_statuses row for the given
+// check that was recorded strictly before the given cutoff. The cutoff must
+// predate the current run's persisted status so that the current result is
+// excluded and the returned row reflects the prior state. This is required
+// because SaveResults commits the current run's status before this lookup.
+func LatestCheckStatus(ctx context.Context, checkID string, before time.Time) (*models.CheckStatus, error) {
 	if checkID == "" || uuid.Nil.String() == checkID {
 		return nil, nil
 	}
 	var status models.CheckStatus
-	if err := ctx.DB().Limit(1).Select("time, created_at, status").Where("check_id = ?", checkID).Order("time DESC").Find(&status).Error; err != nil {
+	if err := ctx.DB().Limit(1).Select("time, created_at, status").
+		Where("check_id = ? AND time < ?", checkID, before.UTC().Format(time.RFC3339)).
+		Order("time DESC").Find(&status).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}

--- a/pkg/jobs/canary/canary_jobs.go
+++ b/pkg/jobs/canary/canary_jobs.go
@@ -128,12 +128,16 @@ func (j CanaryJob) Run(ctx dutyjob.JobRuntime) error {
 		}
 	}
 
+	// Capture the cutoff before SaveResults so LatestCheckStatus excludes the
+	// current run's just-persisted status and compares against the prior state.
+	now := time.Now()
+
 	transformedChecksCreated, checkIDDeleteStrategyMap, err := SaveResults(ctx.Context, results)
 	if err != nil {
 		return fmt.Errorf("failed to save results: %w", err)
 	}
 
-	UpdateCanaryStatusAndEvent(ctx.Context, j.Canary, results)
+	UpdateCanaryStatusAndEvent(ctx.Context, j.Canary, results, now)
 
 	checkDeleteStrategyGroup := make(map[string][]string)
 	checkIDsToRemove := utils.SetDifference(existingTransformedChecks, transformedChecksCreated)

--- a/pkg/jobs/canary/status.go
+++ b/pkg/jobs/canary/status.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func UpdateCanaryStatusAndEvent(ctx context.Context, canary v1.Canary, results []*pkg.CheckResult) {
+func UpdateCanaryStatusAndEvent(ctx context.Context, canary v1.Canary, results []*pkg.CheckResult, now time.Time) {
 	if CanaryStatusChannel == nil {
 		return
 	}
@@ -40,7 +40,6 @@ func UpdateCanaryStatusAndEvent(ctx context.Context, canary v1.Canary, results [
 	var highestLatency float64
 	var uptimeAgg dutyTypes.Uptime
 
-	transitioned := false
 	for _, result := range results {
 		// Increment duration
 		duration += result.Duration
@@ -62,13 +61,14 @@ func UpdateCanaryStatusAndEvent(ctx context.Context, canary v1.Canary, results [
 			highestLatency = latency.Rolling1H
 		}
 
+		transitioned := false
 		// Transition
 		// q := query.CheckQueryParams{Check: checkID, StatusCount: 1}
 		// if canary.Status.LastTransitionedTime != nil {
 		// 	q.Start = canary.Status.LastTransitionedTime.Format(time.RFC3339)
 		// }
 
-		latestCheckStatus, err := db.LatestCheckStatus(ctx, checkID)
+		latestCheckStatus, err := db.LatestCheckStatus(ctx, checkID, now)
 		if err != nil || latestCheckStatus == nil {
 			transitioned = true
 		} else if latestCheckStatus.Status != result.Pass {

--- a/pkg/jobs/canary/status.go
+++ b/pkg/jobs/canary/status.go
@@ -75,13 +75,8 @@ func UpdateCanaryStatusAndEvent(ctx context.Context, canary v1.Canary, results [
 			transitioned = true
 		}
 		if transitioned {
-			transitionTime := time.Now()
-			if latestCheckStatus != nil {
-				transitionTime = latestCheckStatus.CreatedAt
-			}
-
-			checkStatus[checkID].LastTransitionedTime = &metav1.Time{Time: transitionTime}
-			lastTransitionedTime = &metav1.Time{Time: transitionTime}
+			checkStatus[checkID].LastTransitionedTime = &metav1.Time{Time: now}
+			lastTransitionedTime = &metav1.Time{Time: now}
 		}
 
 		if result.Message != "" {


### PR DESCRIPTION
UpdateCanaryStatusAndEvent detects status transitions by comparing the current result against the latest stored check_status. But SaveResults commits the current run's status before that lookup runs, so LatestCheckStatus returned the just-saved current result and the comparison was always equal. transitioned was never set, lastTransitionedTime was never written, and the LAST TRANSITIONED column was always empty (verified: kubectl get canary <name> -o yaml has no lastTransitionedTime key).

Capture a cutoff time before persisting results and pass it to LatestCheckStatus so it only considers rows strictly older than the current run — comparing against the prior state instead of itself. Also reset the transitioned flag per-result to avoid carrying transition state across checks in multi-check canaries.

Fixes #2999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where status change detection was incorrectly including the current run's results in comparisons, preventing proper status transition tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->