### PR TITLE
fix: allow full resource requests/limits on db.external.resources

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -6,7 +6,7 @@ Kubernetes native, multi-tenant synthetic monitoring system
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://flanksource.github.io/charts | flanksource-ui | 1.0.772 |
+| https://flanksource.github.io/charts | flanksource-ui | 1.4.212 |
 
 ## Values
 
@@ -54,6 +54,8 @@ Kubernetes native, multi-tenant synthetic monitoring system
 | db.external.create | bool | `false` | If false and an existing connection must be specified under secretKeyRef If create=false, a prexisting secret containing the URI to an existing postgres database must be provided   The URI must be in the format `postgresql://$user:$password@$host/$database` |
 | db.external.enabled | bool | `false` | Setting to true will disable the embedded DB |
 | db.external.image | string | `"supabase/postgres"` |  |
+| db.external.resources.limits.memory | string | `"4Gi"` |  |
+| db.external.resources.requests.cpu | string | `"200m"` |  |
 | db.external.resources.requests.memory | string | `"2Gi"` |  |
 | db.external.secretKeyRef.key | string | `"DB_URL"` |  |
 | db.external.secretKeyRef.name | string | `"canary-checker-postgres"` | name of secret containing external db credentials |
@@ -74,6 +76,8 @@ Kubernetes native, multi-tenant synthetic monitoring system
 | flanksource-ui.ingress.annotations | object | `{}` |  |
 | flanksource-ui.ingress.enabled | bool | `true` |  |
 | flanksource-ui.ingress.host | string | `"canary-checker-ui.local"` |  |
+| flanksource-ui.ingress.path | string | `"/"` |  |
+| flanksource-ui.ingress.pathType | string | `"ImplementationSpecific"` |  |
 | flanksource-ui.ingress.tls | list | `[]` |  |
 | flanksource-ui.resources.limits.cpu | string | `"200m"` |  |
 | flanksource-ui.resources.limits.memory | string | `"512Mi"` |  |
@@ -95,6 +99,8 @@ Kubernetes native, multi-tenant synthetic monitoring system
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` | Expose the canary-checker service on an ingress, normally not needed as the service is exposed through `flanksource-ui.ingress` |
 | ingress.host | string | `"canary-checker"` |  |
+| ingress.path | string | `"/"` |  |
+| ingress.pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
 | jsonLogs | bool | `true` |  |
 | labelsAllowList | list | `[]` | List of additional check label keys that should be included in the check metrics |

--- a/chart/values.schema.deref.json
+++ b/chart/values.schema.deref.json
@@ -837,28 +837,59 @@
               "title": "image"
             },
             "resources": {
-              "additionalProperties": false,
+              "description": "ResourceRequirements describes the compute resource requirements.",
               "properties": {
-                "requests": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "memory": {
-                      "default": "2Gi",
-                      "title": "memory",
-                      "type": "string"
-                    }
+                "claims": {
+                  "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                  "items": {
+                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                    "properties": {
+                      "name": {
+                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object"
                   },
-                  "required": [
-                    "memory"
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "name"
                   ],
-                  "title": "requests",
+                  "x-kubernetes-list-type": "map"
+                },
+                "limits": {
+                  "additionalProperties": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  },
+                  "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                },
+                "requests": {
+                  "additionalProperties": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  },
+                  "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
                 }
               },
-              "required": [
-                "requests"
-              ],
-              "title": "resources"
+              "type": "object"
             },
             "secretKeyRef": {
               "additionalProperties": false,

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -85,28 +85,7 @@
               "title": "image"
             },
             "resources": {
-              "additionalProperties": false,
-              "properties": {
-                "requests": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "memory": {
-                      "default": "2Gi",
-                      "title": "memory",
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "memory"
-                  ],
-                  "title": "requests",
-                  "type": "object"
-                }
-              },
-              "required": [
-                "requests"
-              ],
-              "title": "resources"
+              "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
             },
             "secretKeyRef": {
               "additionalProperties": false,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -319,10 +319,14 @@ db:
 
     # @schema
     # required: false
+    # $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements
     # @schema
     resources:
       requests:
+        cpu: 200m
         memory: 2Gi
+      limits:
+        memory: 4Gi
 
 # @schema
 # required: false


### PR DESCRIPTION
Users reported `helm install` failing with:

```
db.resources.requests: Additional property cpu is not allowed
```

The `db.external.resources` schema was inferred strictly from the values present (`requests.memory` only) and emitted `additionalProperties: false`, rejecting `requests.cpu` and any `limits`.

Add a `\$ref` to the Kubernetes `ResourceRequirements` schema (same pattern already used by the top-level `resources`), so requests/limits with cpu and memory are all accepted. Shipped defaults: `requests.cpu: 200m`, `requests.memory: 2Gi`, `limits.memory: 4Gi`. No field is required, so users can set e.g. `limits.cpu` without a default.

Derived files (`values.schema.json`, `values.schema.deref.json`, `README.md`) regenerated via `make -C chart chart`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated chart documentation with new version requirements and ingress path configuration options
* **Configuration**
  * Enhanced database resource defaults with CPU request and memory limit specifications
  * Expanded resource configuration to support full Kubernetes resource requirement options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->