### PR TITLE
fix(rbac): grant events.k8s.io create/patch 

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -142,6 +142,15 @@ rules:
     verbs:
       - create
       - patch
+  # events.k8s.io/v1 Events are written by the controller-runtime v2
+  # EventRecorder (mgr.GetEventRecorder) used by the canary/system controllers.
+  - apiGroups:
+      - "events.k8s.io"
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
   # for leader election
   - apiGroups:
       - ""

--- a/config/base/rbac.yaml
+++ b/config/base/rbac.yaml
@@ -97,6 +97,15 @@ rules:
     verbs:
       - create
       - patch
+  # events.k8s.io/v1 Events are written by the controller-runtime v2
+  # EventRecorder (mgr.GetEventRecorder) used by the canary/system controllers.
+  - apiGroups:
+      - "events.k8s.io"
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
   # for leader election
   - apiGroups:
       - ""

--- a/config/deploy/base.yaml
+++ b/config/deploy/base.yaml
@@ -219,6 +219,13 @@ rules:
       - create
       - patch
   - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
       - ""
     resources:
       - configmaps

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -8816,6 +8816,13 @@ rules:
       - create
       - patch
   - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
       - ""
     resources:
       - configmaps


### PR DESCRIPTION
Fixes #3003

## Context

The canary checker pod logged repeated API server rejections whenever a canary failed:

```
events.events.k8s.io is forbidden: User "system:serviceaccount:mission-control:canary-checker-sa"
cannot create resource "events" in API group "events.k8s.io" in the namespace "canaries"
```

## Root cause

The canary and system controllers emit Kubernetes events via controller-runtime's v2 `EventRecorder` (`mgr.GetEventRecorder` in `pkg/controllers/canary_controller.go` and `system_controller.go`), which writes `events.k8s.io/v1` `Event` objects. The chart and kustomize RBAC only granted `create`/`patch` on core `""` (legacy v1) `events`, so every v2 event create was forbidden. This stayed hidden on healthy canaries because events are only emitted on the `Failed` reconcile path.

## Fix

Add an `events.k8s.io` `create`/`patch` rule to:
- `chart/templates/rbac.yaml`
- `config/base/rbac.yaml`
- regenerated deploy bundles `config/deploy/base.yaml` and `config/deploy/manifests.yaml`

The existing core `""` `events` rule is retained for any legacy code paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes RBAC permissions across multiple configurations to enable proper event recording and tracking. Controllers now have appropriate permissions to create and patch system events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->