### PR TITLE
chore: add OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <p>
     <a href="https://github.com/flanksource/canary-checker/actions"><img src="https://github.com/flanksource/canary-checker/workflows/Test/badge.svg"></a>
     <a href="https://goreportcard.com/report/github.com/flanksource/canary-checker"><img src="https://goreportcard.com/badge/github.com/flanksource/canary-checker"></a>
+    <a href="https://securityscorecards.dev/viewer/?uri=github.com/flanksource/canary-checker"><img src="https://api.securityscorecards.dev/projects/github.com/flanksource/canary-checker/badge"></a>
     <img src="https://img.shields.io/github/license/flanksource/canary-checker.svg?style=flat-square"/>
     <a href="https://canarychecker.io"> <img src="https://img.shields.io/badge/☰-Docs-lightgrey.svg"/></a>
   </p>


### PR DESCRIPTION
Add the OpenSSF Scorecard badge to the README so the repository security score is visible from the project homepage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a SecurityScorecards badge/link to the top of the README alongside the existing status badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->