### PR TITLE
fix: skip result templates for failed checks

### DIFF
--- a/checks/runchecks.go
+++ b/checks/runchecks.go
@@ -512,7 +512,7 @@ func contextMapToSlice(c map[string]any) []any {
 }
 
 func processTemplates(ctx *context.Context, r *pkg.CheckResult) *pkg.CheckResult {
-	if r.Invalid {
+	if !r.Pass || r.Invalid {
 		return r
 	}
 	if r.Duration == 0 && r.GetDuration() > 0 {

--- a/checks/runchecks_test.go
+++ b/checks/runchecks_test.go
@@ -4,8 +4,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/flanksource/canary-checker/api/context"
 	"github.com/flanksource/canary-checker/api/external"
 	v1 "github.com/flanksource/canary-checker/api/v1"
+	"github.com/flanksource/canary-checker/pkg"
+	dutycontext "github.com/flanksource/duty/context"
 )
 
 func TestSortChecksByDependency(t *testing.T) {
@@ -156,5 +159,60 @@ func TestSortChecksByDependency(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestProcessTemplatesSkipsFailedResults(t *testing.T) {
+	canary := v1.Canary{}
+	canary.Name = "test-canary"
+	canary.Namespace = "default"
+
+	check := v1.HTTPCheck{
+		Description: v1.Description{Name: "http"},
+		Templatable: v1.Templatable{
+			Display: v1.Template{Expression: "'display overwritten'"},
+			Test:    v1.Template{Expression: "false"},
+		},
+	}
+
+	result := pkg.Success(check, canary)
+	result.Failf("original failure")
+
+	ctx := context.New(dutycontext.New(), canary).WithCheckResult(result)
+	got := processTemplates(ctx, result)
+
+	if got.Message != "" {
+		t.Fatalf("expected failed result message to stay empty, got %q", got.Message)
+	}
+
+	if got.Error != "original failure" {
+		t.Fatalf("expected failed result error to stay unchanged, got %q", got.Error)
+	}
+}
+
+func TestProcessTemplatesAppliesTemplatesToPassedResults(t *testing.T) {
+	canary := v1.Canary{}
+	canary.Name = "test-canary"
+	canary.Namespace = "default"
+
+	check := v1.HTTPCheck{
+		Description: v1.Description{Name: "http"},
+		Templatable: v1.Templatable{
+			Display: v1.Template{Expression: "'display rendered'"},
+			Test:    v1.Template{Expression: "true"},
+		},
+	}
+
+	result := pkg.Success(check, canary)
+
+	ctx := context.New(dutycontext.New(), canary).WithCheckResult(result)
+	got := processTemplates(ctx, result)
+
+	if !got.Pass {
+		t.Fatalf("expected passed result to remain passing, got error %q", got.Error)
+	}
+
+	if got.Message != "display rendered" {
+		t.Fatalf("expected display template to render, got %q", got.Message)
 	}
 }


### PR DESCRIPTION
Display and test templates run after a check produces its base result.

When the base check has already failed, that post-processing can overwrite the original failure message or append a second test failure, making the real check failure harder to read.

Return early for failed results, matching the existing invalid-result behavior, while keeping template processing unchanged for passing results.

This carries forward the narrow result-template behavior from the old closed PR #1813 without bringing over its broader refactors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failed results now skip template-based message rendering, preventing additional processing on non-passing checks.
  * Passing results still render template-based messages as expected.
* **Tests**
  * Added new test cases covering both “skips failed results” and “applies templates to passed results” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->