### PR TITLE
feat(results): classify check failure types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ lint: $(GOLANGCI_LINT)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT): $(LOCALBIN)
-	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION)
+	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 .PHONY: build-api-docs
 build-api-docs:
@@ -243,6 +243,9 @@ ginkgo:
 
 $(RELEASE_DIR):
 	mkdir -p $(RELEASE_DIR)
+
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
 
 .bin:
 	mkdir -p .bin

--- a/checks/runchecks.go
+++ b/checks/runchecks.go
@@ -421,6 +421,7 @@ func TransformResults(ctx *context.Context, in []*pkg.CheckResult) (out []*pkg.C
 			r.Error = fmt.Sprintf("error transforming result: %s", err.Error())
 			r.Invalid = true
 			r.Pass = false
+			r.ClassifyFailure(pkg.FailureEvaluation)
 		} else {
 			for _, t := range transformed {
 				out = append(out, processTemplates(checkCtx, t))
@@ -523,7 +524,7 @@ func processTemplates(ctx *context.Context, r *pkg.CheckResult) *pkg.CheckResult
 		if !v.GetDisplayTemplate().IsEmpty() {
 			message, err := template(ctx, v.GetDisplayTemplate())
 			if err != nil {
-				r.ErrorMessage(ctx.Oops().With(contextMapToSlice(r.GetContext())...).Wrap(err))
+				r.EvaluationErrorMessage(ctx.Oops().With(contextMapToSlice(r.GetContext())...).Wrap(err))
 			} else {
 				r.ResultMessage("%s", message)
 			}
@@ -539,18 +540,18 @@ func processTemplates(ctx *context.Context, r *pkg.CheckResult) *pkg.CheckResult
 
 		message, err := template(ctx, tpl)
 		if err != nil {
-			r.ErrorMessage(ctx.Oops().With(contextMapToSlice(r.GetContext())...).Wrap(err))
+			r.EvaluationErrorMessage(ctx.Oops().With(contextMapToSlice(r.GetContext())...).Wrap(err))
 		} else if parsed, err := strconv.ParseBool(message); err != nil {
-			r.Failf("test expression did not return a boolean value. got %s", message)
+			r.EvaluationErrorf("test expression did not return a boolean value. got %s", message)
 		} else if !parsed {
 			if details, ok := r.Detail.(shell.ExecDetails); ok {
 				if details.Stderr != "" || details.Stdout != "" {
-					r.Failf("%s", strings.TrimSpace(details.Stderr+" "+details.Stdout))
+					r.AssertionFailuref("%s", strings.TrimSpace(details.Stderr+" "+details.Stdout))
 				} else {
-					r.Failf("exit code %d", details.ExitCode)
+					r.AssertionFailuref("exit code %d", details.ExitCode)
 				}
 			} else {
-				r.Failf("test failed")
+				r.AssertionFailuref("test failed")
 			}
 		}
 	}

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -357,6 +357,10 @@ const (
 	// failure "doesn't count".
 	FailureRuntime FailureType = "runtime"
 
+	// FailureEvaluation means user-provided evaluation logic failed while processing
+	// check data, e.g. display, test, or transform expressions.
+	FailureEvaluation FailureType = "evaluation"
+
 	// FailureInvalid means the check specification or user-provided configuration is invalid.
 	FailureInvalid FailureType = "invalid"
 

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -339,6 +339,31 @@ type URL struct {
 
 type SystemResult struct{}
 
+// FailureType classifies why a non-passing check result did not pass.
+type FailureType string
+
+const (
+	// FailureNone means the result has no classified failure.
+	FailureNone FailureType = ""
+
+	// FailureAssertion means the check ran successfully, but its expected condition failed.
+	FailureAssertion FailureType = "assertion"
+
+	// FailureRuntime means the check could not complete due to an execution error,
+	// e.g. connection refused, DNS lookup failure, request timeout, or API client error.
+	//
+	// A FailureRuntime result is still Pass=false and counts as downtime by default;
+	// it records that the check's assertions were never evaluated, not that the
+	// failure "doesn't count".
+	FailureRuntime FailureType = "runtime"
+
+	// FailureInvalid means the check specification or user-provided configuration is invalid.
+	FailureInvalid FailureType = "invalid"
+
+	// FailureInternal means canary-checker itself or an internal dependency failed.
+	FailureInternal FailureType = "internal"
+)
+
 type ArtifactResult struct {
 	ContentType string
 	Path        string
@@ -351,6 +376,7 @@ type CheckResult struct {
 	Start       time.Time              `json:"start,omitempty"`
 	Pass        bool                   `json:"pass,omitempty"`
 	Invalid     bool                   `json:"invalid,omitempty"`
+	FailureType FailureType            `json:"failureType,omitempty"`
 	Detail      interface{}            `json:"detail,omitempty"`
 	Data        map[string]interface{} `json:"data,omitempty"`
 	Labels      map[string]string      `json:"labels,omitempty"`
@@ -371,6 +397,7 @@ type CheckResult struct {
 	ParentCheck external.Check `json:"-"`
 	ErrorObject error          `json:"-"`
 
+	// Deprecated: use FailureType == FailureInternal.
 	InternalError bool `json:"-"`
 
 	CanaryResult []TransformedCanaryResult
@@ -472,6 +499,7 @@ type TransformedCheckResult struct {
 	Start                   *time.Time             `json:"start,omitempty"`
 	Pass                    *bool                  `json:"pass,omitempty"`
 	Invalid                 *bool                  `json:"invalid,omitempty"`
+	FailureType             FailureType            `json:"failureType,omitempty"`
 	Detail                  interface{}            `json:"detail,omitempty"`
 	Data                    map[string]interface{} `json:"data,omitempty"`
 	DeletedAt               *time.Time             `json:"deletedAt,omitempty"`
@@ -515,6 +543,7 @@ func (t TransformedCheckResult) ToCheckResult() CheckResult {
 		Start:       utils.Deref(t.Start, time.Now()),
 		Pass:        utils.Deref(t.Pass, false),
 		Invalid:     utils.Deref(t.Invalid, false),
+		FailureType: t.FailureType,
 		Detail:      t.Detail,
 		Data:        t.Data,
 		Duration:    utils.Deref(t.Duration, 0),

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -401,9 +401,6 @@ type CheckResult struct {
 	ParentCheck external.Check `json:"-"`
 	ErrorObject error          `json:"-"`
 
-	// Deprecated: use FailureType == FailureInternal.
-	InternalError bool `json:"-"`
-
 	CanaryResult []TransformedCanaryResult
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -287,7 +287,7 @@ func Record(
 		switch {
 		case result.Invalid:
 			OpsInvalidCount.WithLabelValues(checkMetricLabels...).Inc()
-		case result.InternalError:
+		case result.FailureType == pkg.FailureInternal:
 			OpsErrorCount.WithLabelValues(checkMetricLabels...).Inc()
 		default:
 			fail.Append(1)

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -49,14 +49,14 @@ func newFixture(checkName, checkKey string) (v1.Canary, pkg.GenericCheck) {
 	return canary, check
 }
 
-func resultFor(canary v1.Canary, check pkg.GenericCheck, pass, invalid, internalErr bool) *pkg.CheckResult {
+func resultFor(canary v1.Canary, check pkg.GenericCheck, pass, invalid bool, failureType pkg.FailureType) *pkg.CheckResult {
 	return &pkg.CheckResult{
-		Pass:          pass,
-		Invalid:       invalid,
-		InternalError: internalErr,
-		Duration:      10,
-		Check:         check,
-		Canary:        canary,
+		Pass:        pass,
+		Invalid:     invalid,
+		FailureType: failureType,
+		Duration:    10,
+		Check:       check,
+		Canary:      canary,
 	}
 }
 
@@ -80,7 +80,7 @@ func TestRecord_FailedCountNotDoubleRecorded(t *testing.T) {
 		name             string
 		pass             bool
 		invalid          bool
-		internalErr      bool
+		failureType      pkg.FailureType
 		wantFailedDelta  float64
 		wantInvalidDelta float64
 		wantErrorDelta   float64
@@ -106,7 +106,7 @@ func TestRecord_FailedCountNotDoubleRecorded(t *testing.T) {
 		{
 			name:           "internal error failure",
 			pass:           false,
-			internalErr:    true,
+			failureType:    pkg.FailureInternal,
 			wantErrorDelta: 1,
 			// internal errors drop out of the uptime ratio: neither pass nor fail.
 			wantUptimeFailed: 0,
@@ -135,7 +135,7 @@ func TestRecord_FailedCountNotDoubleRecorded(t *testing.T) {
 			beforeError := testutil.ToFloat64(OpsErrorCount.WithLabelValues(labels...))
 			beforeSuccess := testutil.ToFloat64(OpsSuccessCount.WithLabelValues(labels...))
 
-			uptime, _ := Record(ctx, canary, resultFor(canary, check, tc.pass, tc.invalid, tc.internalErr))
+			uptime, _ := Record(ctx, canary, resultFor(canary, check, tc.pass, tc.invalid, tc.failureType))
 
 			if got := testutil.ToFloat64(OpsFailedCount.WithLabelValues(labels...)) - beforeFailed; got != tc.wantFailedDelta {
 				t.Errorf("canary_check_failed_count delta = %v, want %v", got, tc.wantFailedDelta)

--- a/pkg/results.go
+++ b/pkg/results.go
@@ -140,6 +140,27 @@ func (result *CheckResult) RuntimeErrorf(message string, args ...interface{}) *C
 	return result.failf(FailureRuntime, message, args...)
 }
 
+func (result *CheckResult) EvaluationErrorf(message string, args ...interface{}) *CheckResult {
+	failureType := FailureEvaluation
+	if !result.Pass && result.FailureType == FailureNone {
+		failureType = FailureNone
+	}
+	return result.failf(failureType, message, args...)
+}
+
+func (result *CheckResult) EvaluationErrorMessage(err error) *CheckResult {
+	if err == nil {
+		return result
+	}
+	result.ErrorObject = err
+	return result.EvaluationErrorf("%s", err.Error())
+}
+
+func (result *CheckResult) ClassifyFailure(failureType FailureType) *CheckResult {
+	result.setFailureType(failureType)
+	return result
+}
+
 func (result *CheckResult) InternalErrorf(message string, args ...interface{}) *CheckResult {
 	result.failf(FailureInternal, message, args...)
 	result.InternalError = true
@@ -202,6 +223,16 @@ func (r Results) AssertionFailuref(msg string, args ...interface{}) Results {
 
 func (r Results) RuntimeErrorf(msg string, args ...interface{}) Results {
 	r[0].RuntimeErrorf(msg, args...)
+	return r
+}
+
+func (r Results) EvaluationErrorf(msg string, args ...interface{}) Results {
+	r[0].EvaluationErrorf(msg, args...)
+	return r
+}
+
+func (r Results) EvaluationErrorMessage(err error) Results {
+	r[0].EvaluationErrorMessage(err)
 	return r
 }
 

--- a/pkg/results.go
+++ b/pkg/results.go
@@ -14,11 +14,12 @@ type Results []*CheckResult
 
 func Invalid(check external.Check, canary v1.Canary, reason string) Results {
 	return Results{&CheckResult{
-		Start:   time.Now(),
-		Pass:    false,
-		Invalid: true,
-		Error:   reason,
-		Check:   check,
+		Start:       time.Now(),
+		Pass:        false,
+		Invalid:     true,
+		FailureType: FailureInvalid,
+		Error:       reason,
+		Check:       check,
 		Data: map[string]interface{}{
 			"results": make(map[string]interface{}),
 		},
@@ -30,12 +31,13 @@ func SetupError(canary v1.Canary, err error) Results {
 	var results Results
 	for _, check := range canary.Spec.GetAllChecks() {
 		results = append(results, &CheckResult{
-			Start:   time.Now(),
-			Pass:    false,
-			Invalid: true,
-			Error:   err.Error(),
-			Check:   check,
-			Data:    make(map[string]interface{}),
+			Start:       time.Now(),
+			Pass:        false,
+			Invalid:     true,
+			FailureType: FailureInvalid,
+			Error:       err.Error(),
+			Check:       check,
+			Data:        make(map[string]interface{}),
 		})
 	}
 	return results
@@ -63,7 +65,7 @@ func (result *CheckResult) ErrorMessage(err error) *CheckResult {
 		return result
 	}
 	result.ErrorObject = err
-	return result.Failf("%s", err.Error())
+	return result.RuntimeErrorf("%s", err.Error())
 }
 
 func (result *CheckResult) UpdateCheck(check external.Check) *CheckResult {
@@ -104,20 +106,48 @@ func (result *CheckResult) TextResults(textResults bool) *CheckResult {
 	return result
 }
 
-func (result *CheckResult) Failf(message string, args ...interface{}) *CheckResult {
+func (result *CheckResult) setFailureType(failureType FailureType) {
+	if result.FailureType == FailureNone && failureType != FailureNone {
+		result.FailureType = failureType
+	}
+}
+
+func (result *CheckResult) failf(failureType FailureType, message string, args ...interface{}) *CheckResult {
 	if result.Error != "" {
 		result.Error += ", "
 	}
 
-	result.InternalError = db.IsDBError(fmt.Errorf(message, args...))
+	if db.IsDBError(fmt.Errorf(message, args...)) {
+		result.InternalError = true
+		failureType = FailureInternal
+	}
 
 	result.Pass = false
+	result.setFailureType(failureType)
 	result.Error += fmt.Sprintf(message, args...)
 	return result
 }
 
+func (result *CheckResult) Failf(message string, args ...interface{}) *CheckResult {
+	return result.failf(FailureNone, message, args...)
+}
+
+func (result *CheckResult) AssertionFailuref(message string, args ...interface{}) *CheckResult {
+	return result.failf(FailureAssertion, message, args...)
+}
+
+func (result *CheckResult) RuntimeErrorf(message string, args ...interface{}) *CheckResult {
+	return result.failf(FailureRuntime, message, args...)
+}
+
+func (result *CheckResult) InternalErrorf(message string, args ...interface{}) *CheckResult {
+	result.failf(FailureInternal, message, args...)
+	result.InternalError = true
+	return result
+}
+
 func (result *CheckResult) Invalidf(message string, args ...interface{}) Results {
-	result = result.Failf(message, args...)
+	result = result.failf(FailureInvalid, message, args...)
 	result.Invalid = true
 	return Results{result}
 }
@@ -162,6 +192,21 @@ func (result *CheckResult) AddData(data map[string]interface{}) *CheckResult {
 
 func (r Results) Failf(msg string, args ...interface{}) Results {
 	r[0].Failf(msg, args...)
+	return r
+}
+
+func (r Results) AssertionFailuref(msg string, args ...interface{}) Results {
+	r[0].AssertionFailuref(msg, args...)
+	return r
+}
+
+func (r Results) RuntimeErrorf(msg string, args ...interface{}) Results {
+	r[0].RuntimeErrorf(msg, args...)
+	return r
+}
+
+func (r Results) InternalErrorf(msg string, args ...interface{}) Results {
+	r[0].InternalErrorf(msg, args...)
 	return r
 }
 

--- a/pkg/results.go
+++ b/pkg/results.go
@@ -106,15 +106,10 @@ func (result *CheckResult) TextResults(textResults bool) *CheckResult {
 	return result
 }
 
-func (result *CheckResult) syncFailureCompatibilityFields() {
-	result.InternalError = result.FailureType == FailureInternal
-}
-
 func (result *CheckResult) setFailureType(failureType FailureType) {
 	if result.FailureType == FailureNone && failureType != FailureNone {
 		result.FailureType = failureType
 	}
-	result.syncFailureCompatibilityFields()
 }
 
 func (result *CheckResult) failf(failureType FailureType, message string, args ...interface{}) *CheckResult {

--- a/pkg/results.go
+++ b/pkg/results.go
@@ -106,10 +106,15 @@ func (result *CheckResult) TextResults(textResults bool) *CheckResult {
 	return result
 }
 
+func (result *CheckResult) syncFailureCompatibilityFields() {
+	result.InternalError = result.FailureType == FailureInternal
+}
+
 func (result *CheckResult) setFailureType(failureType FailureType) {
 	if result.FailureType == FailureNone && failureType != FailureNone {
 		result.FailureType = failureType
 	}
+	result.syncFailureCompatibilityFields()
 }
 
 func (result *CheckResult) failf(failureType FailureType, message string, args ...interface{}) *CheckResult {
@@ -118,7 +123,6 @@ func (result *CheckResult) failf(failureType FailureType, message string, args .
 	}
 
 	if db.IsDBError(fmt.Errorf(message, args...)) {
-		result.InternalError = true
 		failureType = FailureInternal
 	}
 
@@ -162,9 +166,7 @@ func (result *CheckResult) ClassifyFailure(failureType FailureType) *CheckResult
 }
 
 func (result *CheckResult) InternalErrorf(message string, args ...interface{}) *CheckResult {
-	result.failf(FailureInternal, message, args...)
-	result.InternalError = true
-	return result
+	return result.failf(FailureInternal, message, args...)
 }
 
 func (result *CheckResult) Invalidf(message string, args ...interface{}) Results {

--- a/pkg/results_test.go
+++ b/pkg/results_test.go
@@ -1,0 +1,95 @@
+package pkg
+
+import (
+	"errors"
+	"testing"
+
+	v1 "github.com/flanksource/canary-checker/api/v1"
+)
+
+func TestCheckResultFailureTypes(t *testing.T) {
+	canary := v1.Canary{}
+	check := v1.HTTPCheck{}
+
+	t.Run("legacy failure is unclassified", func(t *testing.T) {
+		result := Success(check, canary)
+		result.Failf("expected %d, got %d", 404, 200)
+
+		if result.Pass {
+			t.Fatal("expected result to fail")
+		}
+		if result.FailureType != FailureNone {
+			t.Fatalf("expected failure type %q, got %q", FailureNone, result.FailureType)
+		}
+	})
+
+	t.Run("assertion failure", func(t *testing.T) {
+		result := Success(check, canary)
+		result.AssertionFailuref("expected %d, got %d", 404, 200)
+
+		if result.Pass {
+			t.Fatal("expected result to fail")
+		}
+		if result.FailureType != FailureAssertion {
+			t.Fatalf("expected failure type %q, got %q", FailureAssertion, result.FailureType)
+		}
+	})
+
+	t.Run("runtime error", func(t *testing.T) {
+		result := Success(check, canary)
+		err := errors.New("connection refused")
+		result.ErrorMessage(err)
+
+		if result.Pass {
+			t.Fatal("expected result to fail")
+		}
+		if result.FailureType != FailureRuntime {
+			t.Fatalf("expected failure type %q, got %q", FailureRuntime, result.FailureType)
+		}
+		if result.ErrorObject != err {
+			t.Fatal("expected original error to be preserved")
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		result := Success(check, canary)
+		result.Invalidf("missing url")
+
+		if !result.Invalid {
+			t.Fatal("expected result to be invalid")
+		}
+		if result.FailureType != FailureInvalid {
+			t.Fatalf("expected failure type %q, got %q", FailureInvalid, result.FailureType)
+		}
+	})
+
+	t.Run("internal error", func(t *testing.T) {
+		result := Success(check, canary)
+		result.InternalErrorf("failed to persist status")
+
+		if !result.InternalError {
+			t.Fatal("expected result to be marked internal error")
+		}
+		if result.FailureType != FailureInternal {
+			t.Fatalf("expected failure type %q, got %q", FailureInternal, result.FailureType)
+		}
+	})
+}
+
+func TestFailureTypeFirstClassificationWins(t *testing.T) {
+	result := Success(v1.HTTPCheck{}, v1.Canary{})
+
+	result.AssertionFailuref("expected 404")
+	result.ErrorMessage(errors.New("display template failed"))
+
+	if result.FailureType != FailureAssertion {
+		t.Fatalf("expected failure type %q, got %q", FailureAssertion, result.FailureType)
+	}
+
+	result.RuntimeErrorf("connection refused")
+	result.Invalidf("missing url")
+
+	if result.FailureType != FailureAssertion {
+		t.Fatalf("expected failure type %q, got %q", FailureAssertion, result.FailureType)
+	}
+}

--- a/pkg/results_test.go
+++ b/pkg/results_test.go
@@ -51,6 +51,22 @@ func TestCheckResultFailureTypes(t *testing.T) {
 		}
 	})
 
+	t.Run("evaluation error", func(t *testing.T) {
+		result := Success(check, canary)
+		err := errors.New("display template failed")
+		result.EvaluationErrorMessage(err)
+
+		if result.Pass {
+			t.Fatal("expected result to fail")
+		}
+		if result.FailureType != FailureEvaluation {
+			t.Fatalf("expected failure type %q, got %q", FailureEvaluation, result.FailureType)
+		}
+		if result.ErrorObject != err {
+			t.Fatal("expected original error to be preserved")
+		}
+	})
+
 	t.Run("invalid", func(t *testing.T) {
 		result := Success(check, canary)
 		result.Invalidf("missing url")
@@ -80,7 +96,7 @@ func TestFailureTypeFirstClassificationWins(t *testing.T) {
 	result := Success(v1.HTTPCheck{}, v1.Canary{})
 
 	result.AssertionFailuref("expected 404")
-	result.ErrorMessage(errors.New("display template failed"))
+	result.EvaluationErrorMessage(errors.New("display template failed"))
 
 	if result.FailureType != FailureAssertion {
 		t.Fatalf("expected failure type %q, got %q", FailureAssertion, result.FailureType)
@@ -91,5 +107,16 @@ func TestFailureTypeFirstClassificationWins(t *testing.T) {
 
 	if result.FailureType != FailureAssertion {
 		t.Fatalf("expected failure type %q, got %q", FailureAssertion, result.FailureType)
+	}
+}
+
+func TestEvaluationErrorPreservesLegacyUnclassifiedFailure(t *testing.T) {
+	result := Success(v1.HTTPCheck{}, v1.Canary{})
+
+	result.Failf("expected 404")
+	result.EvaluationErrorMessage(errors.New("display template failed"))
+
+	if result.FailureType != FailureNone {
+		t.Fatalf("expected failure type %q, got %q", FailureNone, result.FailureType)
 	}
 }

--- a/pkg/results_test.go
+++ b/pkg/results_test.go
@@ -104,7 +104,11 @@ func TestFailureTypeFirstClassificationWins(t *testing.T) {
 
 	result.RuntimeErrorf("connection refused")
 	result.Invalidf("missing url")
+	result.InternalErrorf("failed to persist status")
 
+	if result.InternalError {
+		t.Fatal("expected internal error compatibility flag to follow failure type")
+	}
 	if result.FailureType != FailureAssertion {
 		t.Fatalf("expected failure type %q, got %q", FailureAssertion, result.FailureType)
 	}

--- a/pkg/results_test.go
+++ b/pkg/results_test.go
@@ -83,9 +83,6 @@ func TestCheckResultFailureTypes(t *testing.T) {
 		result := Success(check, canary)
 		result.InternalErrorf("failed to persist status")
 
-		if !result.InternalError {
-			t.Fatal("expected result to be marked internal error")
-		}
 		if result.FailureType != FailureInternal {
 			t.Fatalf("expected failure type %q, got %q", FailureInternal, result.FailureType)
 		}
@@ -106,9 +103,6 @@ func TestFailureTypeFirstClassificationWins(t *testing.T) {
 	result.Invalidf("missing url")
 	result.InternalErrorf("failed to persist status")
 
-	if result.InternalError {
-		t.Fatal("expected internal error compatibility flag to follow failure type")
-	}
 	if result.FailureType != FailureAssertion {
 		t.Fatalf("expected failure type %q, got %q", FailureAssertion, result.FailureType)
 	}


### PR DESCRIPTION
Introduce a `FailureType` on check results to distinguish why a non-passing check did not pass.

This adds explicit categories for assertion, runtime, evaluation, invalid, and internal failures while keeping legacy `Failf` unclassified so unaudited call sites remain visible during migration.

`ErrorMessage` now classifies runtime failures, expression/template paths classify evaluation failures, `Invalidf` classifies invalid results, and the first classification wins to preserve the primary failure cause.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured failure categories via a new `failureType` field on check results (assertion, runtime, evaluation/invalid, and internal), including exported failure constants.
  * Added new `Results` failure helper methods to set `failureType`.
* **Bug Fixes**
  * Improved failure classification consistency and ensured the first detected `failureType` takes precedence.
  * Transformer and template-related failures are now categorized more accurately (evaluation vs assertion vs runtime).
  * Metrics for internal-error results now rely on `failureType`.
* **Documentation**
  * Removed the legacy internal-error flag in favor of `failureType == internal`.
* **Tests**
  * Added unit tests covering classification assignment and precedence.
* **Chores**
  * Updated lint installation to use `go install` and added a local binary directory target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->