### PR TITLE
chore: add config parser fuzzing

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,30 @@
+name: Go Fuzz
+
+on:
+  pull_request:
+  schedule:
+    - cron: '17 2 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: 1.26.x
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: fuzz-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            fuzz-
+      - name: Fuzz config parser
+        run: make fuzz FUZZTIME=30s

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,9 +1,9 @@
 name: Go Fuzz
 
 on:
-  pull_request:
   schedule:
     - cron: '17 2 * * 1'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -11,20 +11,22 @@ permissions:
 jobs:
   fuzz:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      FUZZTIME: 10m
     steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.26.x
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: fuzz-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            fuzz-
       - name: Fuzz config parser
-        run: make fuzz FUZZTIME=30s
+        run: make fuzz FUZZTIME="${FUZZTIME}"
+      - name: Upload fuzz crashers
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-crashers
+          path: pkg/testdata/fuzz/FuzzParseConfig/
+          if-no-files-found: ignore

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -24,6 +24,8 @@ jobs:
           key: cache-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             cache-
+      - name: Test fuzz seed corpus
+        run: go test ./pkg -run=FuzzParseConfig -count=1
       - name: Test
         run: make test
       - name: Publish Unit Test Results

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 GOLANGCI_LINT_VERSION ?= v2.8.0
+FUZZTIME ?= 30s
 
 # Image URL to use all building/pushing image targets
 IMG_F ?= docker.io/flanksource/canary-checker-full:${VERSION_TAG}
@@ -40,6 +41,10 @@ all: manager
 .PHONY: test
 test: manifests generate fmt ginkgo
 	ginkgo -vv -r  --cover  --keep-going --junit-report junit-report.xml --
+
+.PHONY: fuzz
+fuzz:
+	go test ./pkg -run=FuzzParseConfig -fuzz=FuzzParseConfig -fuzztime=$(FUZZTIME)
 
 .PHONY: test\:fixtures
 test\:fixtures:

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -112,6 +112,10 @@ func ParseConfig(configfile string, datafile string) ([]v1.Canary, error) {
 		}
 	}
 
+	return parseConfig(configs)
+}
+
+func parseConfig(configs string) ([]v1.Canary, error) {
 	var canaries []v1.Canary
 	re := regexp.MustCompile(`(?m)^---\n`)
 	for _, chunk := range re.Split(configs, -1) {

--- a/pkg/config_fuzz_test.go
+++ b/pkg/config_fuzz_test.go
@@ -1,0 +1,71 @@
+package pkg
+
+import (
+	"os"
+	"testing"
+)
+
+func FuzzParseConfig(f *testing.F) {
+	for _, seed := range []string{
+		`apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: http-checks
+spec:
+  schedule: "@every 5m"
+  http:
+    - name: http-pass
+      url: https://example.com
+      responseCodes: [200, 204]
+`,
+		`schedule: "@every 1m"
+http:
+  - name: spec-only
+    url: https://example.com/health
+    responseContent: ok
+`,
+		`apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: multi-doc-one
+spec:
+  exec:
+    - name: echo
+      script: echo ok
+---
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: multi-doc-two
+spec:
+  webhook:
+    transform:
+      expr: 'true'
+`,
+		`http:
+  - name: templated-body
+    url: https://example.com
+    body: '{{ .payload }}'
+    templateBody: true
+`,
+		`---
+not: [valid
+`,
+	} {
+		f.Add([]byte(seed))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Keep fuzz inputs bounded so parser/resource regressions are attributable and CI-friendly.
+		if len(data) > 1<<20 {
+			return
+		}
+
+		configFile := t.TempDir() + "/canary.yaml"
+		if err := os.WriteFile(configFile, data, 0o600); err != nil {
+			t.Fatalf("write fuzz config: %v", err)
+		}
+
+		_, _ = ParseConfig(configFile, "")
+	})
+}

--- a/pkg/config_fuzz_test.go
+++ b/pkg/config_fuzz_test.go
@@ -1,9 +1,6 @@
 package pkg
 
-import (
-	"os"
-	"testing"
-)
+import "testing"
 
 func FuzzParseConfig(f *testing.F) {
 	for _, seed := range []string{
@@ -61,11 +58,6 @@ not: [valid
 			return
 		}
 
-		configFile := t.TempDir() + "/canary.yaml"
-		if err := os.WriteFile(configFile, data, 0o600); err != nil {
-			t.Fatalf("write fuzz config: %v", err)
-		}
-
-		_, _ = ParseConfig(configFile, "")
+		_, _ = parseConfig(string(data))
 	})
 }


### PR DESCRIPTION
Add a Go fuzz target for Canary config parsing, covering full CRD YAML, spec-only YAML, multi-document configs, templated fields, and malformed input.

This exercises the repo’s user-facing config ingestion path and adds a scheduled fuzz workflow so regressions are continuously checked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added fuzz coverage for configuration parsing with multiple seeded YAML cases and arbitrary inputs.
  * Expanded Go test validation to include the fuzz seed corpus.

* **Chores**
  * Added a reusable fuzzing target to run on demand or in scheduled automation.
  * Introduced a weekly and manual fuzz workflow, with artifact upload on failures to help surface crashes faster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->