### PR TITLE
docs: refresh README status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@
 
   <p>Kubernetes Native Health Check Platform</p>
   <p>
-    <a href="https://github.com/flanksource/canary-checker/actions"><img src="https://github.com/flanksource/canary-checker/workflows/Test/badge.svg"></a>
-    <a href="https://goreportcard.com/report/github.com/flanksource/canary-checker"><img src="https://goreportcard.com/badge/github.com/flanksource/canary-checker"></a>
+    <a href="https://github.com/flanksource/canary-checker/actions/workflows/test.yml"><img src="https://github.com/flanksource/canary-checker/actions/workflows/test.yml/badge.svg?branch=master"></a>
+    <a href="https://github.com/flanksource/canary-checker/actions/workflows/lint.yml"><img src="https://github.com/flanksource/canary-checker/actions/workflows/lint.yml/badge.svg?branch=master"></a>
+    <a href="https://github.com/flanksource/canary-checker/actions/workflows/codeql.yml"><img src="https://github.com/flanksource/canary-checker/actions/workflows/codeql.yml/badge.svg?branch=master"></a>
+    <a href="https://hub.docker.com/r/flanksource/canary-checker"><img src="https://img.shields.io/docker/pulls/flanksource/canary-checker?logo=docker&style=flat-square"></a>
     <a href="https://securityscorecards.dev/viewer/?uri=github.com/flanksource/canary-checker"><img src="https://api.securityscorecards.dev/projects/github.com/flanksource/canary-checker/badge"></a>
     <img src="https://img.shields.io/github/license/flanksource/canary-checker.svg?style=flat-square"/>
     <a href="https://canarychecker.io"> <img src="https://img.shields.io/badge/☰-Docs-lightgrey.svg"/></a>


### PR DESCRIPTION
The README still linked to the deprecated Go Report Card badge.

Replace it with current GitHub Actions workflow badges and add Docker pulls visibility while keeping the existing Scorecard, license, and docs badges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README badges section to show current workflow status badges for testing, linting, and code scanning.
  * Added a Docker Hub pull badge.
  * Removed outdated badge entries from the top of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->