### PR TITLE
docs: update README accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,27 +17,27 @@
 </div>
 
 ---
-Canary checker is a kubernetes-native platform for monitoring health across application and infrastructure using both passive and active (synthetic) mechanisms.
+Canary Checker is a Kubernetes-native platform for monitoring application and infrastructure health using both active synthetic checks and passive signal ingestion.
 
 ## Features
 
-* **Batteries Included** - 35+ built-in check types
-* **Kubernetes Native** - Health checks (or canaries) are CRD's that reflect health via the `status` field, making them compatible with GitOps, [Flux Health Checks](https://fluxcd.io/flux/components/kustomize/kustomization/#health-checks), Argo, Helm, etc..
-* **Secret Management** - Leverage K8S secrets and configmaps for authentication and connection details
-* **Prometheus** - Prometheus compatible metrics are exposed at `/metrics`.  A Grafana Dashboard is also available.
-* **Dependency Free** - Runs an embedded postgres instance by default,  can also be configured to use an external database.
+* **Batteries Included** - 30+ built-in active and passive check types
+* **Kubernetes Native** - Health checks, or canaries, are CRDs that reflect health via the `status` field, making them compatible with GitOps, [Flux Health Checks](https://fluxcd.io/flux/components/kustomize/kustomization/#health-checks), Argo, Helm, etc.
+* **Secret Management** - Leverage Kubernetes Secrets and ConfigMaps for authentication and connection details
+* **Prometheus** - Prometheus-compatible metrics are exposed at `/metrics`. A Grafana dashboard is also available.
+* **Self-Contained Storage** - Uses embedded Postgres by default and can be configured to use external Postgres.
 * **JUnit Export (CI/CD)**  - Export health check results to JUnit format for integration into CI/CD pipelines
-* **JUnit Import (k6/newman/puppeter/etc)** - Use any container that creates JUnit test results
-* **Scriptable** - Go templates, Javascript and [CEL](https://canarychecker.io/scripting/cel) can be used to:
+* **JUnit Import (k6/Newman/Puppeteer/etc.)** - Use any container that creates JUnit test results
+* **Scriptable** - Go templates, JavaScript and [CEL](https://canarychecker.io/scripting/cel) can be used to:
   * Evaluate whether a check is passing and severity to use when failing
   * Extract a user friendly error message
   * Transform and filter check responses into individual check results
   * Extract custom metrics
-* **Multi-Modal** - While designed as a Kubernetes Operator, canary checker can also run as a CLI and a server without K8s
+* **Multi-Modal** - While designed as a Kubernetes operator, Canary Checker can also run as a CLI and as a standalone server.
 
 ## Getting Started
 
-1. Install canary checker with Helm
+1. Install Canary Checker with Helm
 
 ```shell
 helm repo add flanksource https://flanksource.github.io/charts
@@ -46,10 +46,10 @@ helm repo update
 helm install \
   canary-checker \
   flanksource/canary-checker \
- -n canary-checker \
- --create-namespace
- --wait
-  ```
+  -n canary-checker \
+  --create-namespace \
+  --wait
+```
 
 2. Create a new check
 
@@ -59,7 +59,7 @@ kind: Canary
 metadata:
   name: http-check
 spec:
-  interval: 30
+  schedule: "@every 30s"
   http:
     - name: basic-check
       url: https://httpbin.flanksource.com/status/200
@@ -90,8 +90,8 @@ kubectl get canary
 ```
 
 ``` title="sample output"
-NAME               INTERVAL   STATUS   LAST CHECK   UPTIME 1H        LATENCY 1H   LAST TRANSITIONED
-http-check.        30         Passed   13s          18/18 (100.0%)   480ms        13s
+NAME         SCHEDULE      STATUS   LAST CHECK   UPTIME 1H        LATENCY 1H   LAST TRANSITIONED
+http-check   @every 30s    Passed   13s          18/18 (100.0%)   480ms        13s
 ```
 
 See [fixtures](https://github.com/flanksource/canary-checker/tree/master/fixtures) for more examples and [docs](https://canarychecker.io/getting-started) for more comprehensive documentation.
@@ -100,7 +100,7 @@ See [fixtures](https://github.com/flanksource/canary-checker/tree/master/fixture
 
 ### Synthetic Testing
 
-Run simple HTTP/DNS/ICMP probes or more advanced full test suites using JMeter, K6, Playright, Postman.
+Run simple HTTP/DNS/ICMP probes or more advanced full test suites using JMeter, k6, Playwright, Postman/Newman, or any container that can emit JUnit XML.
 
 ```yaml
 # Run a container that executes a playwright test, and then collect the
@@ -110,7 +110,7 @@ kind: Canary
 metadata:
   name: playwright-junit
 spec:
-  interval: 120
+  schedule: "@every 2m"
   junit:
     - testResults: "/tmp/"
       name: playwright-junit
@@ -122,41 +122,56 @@ spec:
 
 ### Infrastructure Testing
 
-Verify that infrastructure is fully operational by [deploying new pods](https://canarychecker.io/reference/pod), spinning up new EC2 instances and pushing/pulling from docker and helm repositories.
+Verify that infrastructure is fully operational by checking Kubernetes resources, deploying temporary resources, and running nested checks against them.
 
 ```yaml
-# Schedule a new pod with an ingress and then time how long it takes to schedule, be ready, respond to an http request and finally be cleaned up.
+# Deploy a temporary pod and service, wait for readiness, call the service, and then clean up.
 apiVersion: canaries.flanksource.com/v1
 kind: Canary
 metadata:
-  name: pod-check
+  name: kubernetes-resource-check
 spec:
-  interval: 30
-  pod:
-    - name: golang
-      spec: |
-        apiVersion: v1
-        kind: Pod
-        metadata:
-          name: hello-world-golang
-          namespace: default
-          labels:
-            app: hello-world-golang
-        spec:
-          containers:
-            - name: hello
-              image: quay.io/toni0/hello-webserver-golang:latest
-      port: 8080
-      path: /foo/bar
-      scheduleTimeout: 20000
-      readyTimeout: 10000
-      httpTimeout: 7000
-      deleteTimeout: 12000
-      ingressTimeout: 10000
-      deadline: 60000
-      httpRetryInterval: 200
-      expectedContent: bar
-      expectedHttpStatuses: [200, 201, 202]
+  schedule: "@every 5m"
+  kubernetesResource:
+    - name: service-accessibility
+      namespace: default
+      waitFor:
+        expr: 'dyn(resources).all(r, k8s.isReady(r))'
+        interval: 2s
+        timeout: 2m
+      resources:
+        - apiVersion: v1
+          kind: Pod
+          metadata:
+            name: httpbin-pod
+            namespace: default
+            labels:
+              app: httpbin
+          spec:
+            containers:
+              - name: httpbin
+                image: kennethreitz/httpbin:latest
+                ports:
+                  - containerPort: 80
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            name: httpbin
+            namespace: default
+          spec:
+            selector:
+              app: httpbin
+            ports:
+              - port: 80
+                targetPort: 80
+      checks:
+        - http:
+            - name: call-httpbin-service
+              url: http://httpbin.default.svc/status/200
+      checkRetries:
+        delay: 2s
+        interval: 3s
+        timeout: 2m
 ```
 
 ### Backup Checks / Batch File Monitoring
@@ -170,7 +185,7 @@ kind: Canary
 metadata:
   name: folder-check
 spec:
-  schedule: 0 22 * * *
+  schedule: "0 22 * * *"
   folder:
     - path: s3://database-backups/prod
       name: prod-backup
@@ -180,7 +195,7 @@ spec:
 
 ### Alert Aggregation
 
-Aggregate alerts and recommendations from Prometheus, AWS Cloudwatch, Dynatrace, etc.
+Aggregate alerts and recommendations from Prometheus, AWS CloudWatch, Dynatrace, etc.
 
 ```yaml
 apiVersion: canaries.flanksource.com/v1
@@ -213,7 +228,7 @@ spec:
 
 ### Prometheus Exporter Replacement
 
-Export [custom metrics](https://canarychecker.io/concepts/metrics-exporter) from the result of any check, making it possible to replace various other promethus exporters that collect metrics via HTTP, SQL, etc..
+Export [custom metrics](https://canarychecker.io/concepts/metrics-exporter) from the result of any check, making it possible to replace various other Prometheus exporters that collect metrics via HTTP, SQL, etc.
 
 ```yaml
 apiVersion: canaries.flanksource.com/v1
@@ -221,7 +236,7 @@ kind: Canary
 metadata:
   name: exchange-rates
 spec:
-  schedule: "every 1 @hour"
+  schedule: "@every 1h"
   http:
     - name: exchange-rates
       url: https://api.frankfurter.app/latest?from=USD&to=GBP,EUR,ILS
@@ -238,24 +253,25 @@ spec:
 
 ## Platform Ready
 
-Canary checker is ideal for building platforms, developers can include health checks for their applications in whatever tooling they prefer, with secret management that uses native Kubernetes constructs.
+Canary Checker is ideal for building platforms. Developers can include health checks for their applications in whatever tooling they prefer, with secret management that uses native Kubernetes constructs.
 
 ```yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name:  basic-auth
+  name: basic-auth
 stringData:
-   user: john
-   pass: doe
+  user: john
+  pass: doe
 ---
 apiVersion: canaries.flanksource.com/v1
 kind: Canary
 metadata:
-  name: http-basic-auth-configmap
+  name: http-basic-auth-secret
 spec:
   http:
-    - url: https://httpbin.flanksource.com/basic-auth/john/doe
+    - name: http-basic-auth
+      url: https://httpbin.flanksource.com/basic-auth/john/doe
       username:
         valueFrom:
           secretKeyRef:
@@ -270,77 +286,43 @@ spec:
 
 ## Dashboard
 
-Canary checker comes with a built-in dashboard by default
+Canary Checker comes with a built-in dashboard by default.
 
 ![](https://canarychecker.io/img/canary-ui.png)
 
-There is also a [grafana](https://canarychecker.io/concepts/grafana) dashboard, or build your own using the metrics exposed.
+There is also a [Grafana](https://canarychecker.io/concepts/grafana) dashboard, or build your own using the metrics exposed.
 
 ## Getting Help
 
-If you have any questions about canary checker:
+If you have any questions about Canary Checker:
 
 * Read the [docs](https://canarychecker.io)
 * Invite yourself to the [CNCF community slack](https://slack.cncf.io/) and join the [#canary-checker](https://cloud-native.slack.com/messages/canary-checker/) channel.
-* Check out the [Youtube Playlist](https://www.youtube.com/playlist?list=PLz4F_KggvA58D6krlw433TNr8qMbu1aIU).
-* File an [issue](https://github.com/flanksource/canary-checker/issues/new) - (We do provide user support via Github Issues, so don't worry if your issue is a bug or not)
+* Check out the [YouTube playlist](https://www.youtube.com/playlist?list=PLz4F_KggvA58D6krlw433TNr8qMbu1aIU).
+* File an [issue](https://github.com/flanksource/canary-checker/issues/new) - (We do provide user support via GitHub Issues, so don't worry if your issue is a bug or not)
 
 Your feedback is always welcome!
 
 ## Check Types
 
-| Protocol                                                     | Status     | Checks                                                       |
-| ------------------------------------------------------------ | ---------- | ------------------------------------------------------------ |
-| [HTTP(s)](https://canarychecker.io/reference/http)                                 | GA         | Response body, headers and duration                          |
-| [DNS](https://canarychecker.io/reference/dns)                                      | GA         | Response and duration                                        |
-| [Ping/ICMP](https://canarychecker.io/reference/icmp)                               | GA         | Duration and packet loss                                     |
-| [TCP](https://canarychecker.io/reference/tcp)                                      | GA         | Port is open and connectable                                 |
-| **Data Sources**                                             |            |                                                              |
-| [SQL](https://canarychecker.io/reference/sql) (MySQL, Postgres, SQL Server) | GA         | Ability to login, results, duration, health exposed via stored procedures |
-| [LDAP](https://canarychecker.io/reference/ldap)                                    | GA         | Ability to login, response time                              |
-| [ElasticSearch / Opensearch](https://canarychecker.io/reference/elasticsearch)     | GA         | Ability to login, response time, size of search results      |
-| [Mongo](https://canarychecker.io/reference/mongo)                                  | Beta       | Ability to login, results, duration,                         |
-| [Redis](https://canarychecker.io/reference/redis)                                  | GA         | Ability to login, results, duration,                         |
-| [Prometheus](https://canarychecker.io/reference/prometheus)                        | GA         | Ability to login, results, duration,                         |
-| **Alerts**                                                   |            | Prometheus                                                   |
-| [Prometheus Alert Manager](https://canarychecker.io/reference/alert-manager)       | GA         | Pending and firing alerts                                    |
-| [AWS Cloudwatch Alarms](https://canarychecker.io/reference/aws-cloudwatch)             | GA         | Pending and firing alarms                                    |
-| [Dynatrace Problems](./fixtures/external/dynatrace.yaml)               | Beta       | Problems deteced                                             |
-| **DevOps**                                                   |            |                                                              |
-| [Git](https://canarychecker.io/reference/git)                                      | GA         | Query Git and Github repositories via SQL                    |
-| [Azure Devops](https://canarychecker.io/reference/azure-devops)                                 | Beta |                                                              |
-| **Integration Testing**                                      |            |                                                              |
-| [JMeter](https://canarychecker.io/reference/jmeter)                                | Beta       | Runs and checks the result of a JMeter test                  |
-| [JUnit / BYO](https://canarychecker.io/reference/junit)                            | Beta       | Run a pod that saves Junit test results                      |
-| [K6](https://canarychecker.io/examples/k6) | Beta | Runs K6 tests that export JUnit via a container |
-| [Newman](https://canarychecker.io/examples/newman) | Beta |  Runs Newman / Postman tests that export JUnit via a container  |
-| [Playwright](https://canarychecker.io/examples/Playwright) | Beta |  Runs Playwright tests that export JUnit via a container  |
-| **File Systems / Batch**                                     |            |                                                              |
-| [Local Disk / NFS](https://canarychecker.io/reference/folder)                      | GA         | Check folders for files that are:  too few/many, too old/new, too small/large |
-| [S3](https://canarychecker.io/reference/folder#s3)                                 | GA         | Check contents of AWS S3 Buckets                             |
-| [GCS](https://canarychecker.io/reference/folder#gcs)                               | GA         | Check contents of Google Cloud Storage Buckets               |
-| [SFTP](https://canarychecker.io/reference/folder#sftp)                                    | GA         | Check contents of folders over SFTP                          |
-| [SMB / CIFS](https://canarychecker.io/reference/folder#smb)                                         | GA         | Check contents of folders over SMB/CIFS                      |
-| **Config**                                                   |            |                                                              |
-| [AWS Config](https://canarychecker.io/reference/aws-config)                        | GA         | Query AWS config using SQL                                   |
-| [AWS Config Rule](https://canarychecker.io/reference/aws-config-rule)              | GA         | AWS Config Rules that are firing, Custom AWS Config queries  |
-| [Config DB](https://canarychecker.io/reference/catalog)                           | GA         | Custom config queries for Mission Control Config D           |
-| [Kubernetes Resources](https://canarychecker.io/reference/kubernetes)              | GA         | Kubernetes resources that are missing or are in a non-ready state |
-| **Backups**                                                  |            |                                                              |
-| [GCP Databases](https://canarychecker.io/reference/gcs-database-backup#gcpdatabase)                                    | GA         | Backup freshness                                             |
-| [Restic](https://canarychecker.io/reference/restic)                                | Beta       | Backup freshness and integrity                               |
-| **Infrastructure**                                           |            |                                                              |
-| [EC2](https://canarychecker.io/reference/ec2)                                      | GA         | Ability to launch new EC2 instances                          |
-| [Kubernetes Ingress](https://canarychecker.io/reference/pod)                       | GA         | Ability to schedule and then route traffic via an ingress to a pod |
-| [Docker/Containerd](https://canarychecker.io/reference/containerd)                 | Deprecated | Ability to push and pull containers via docker/containerd    |
-| [Helm](https://canarychecker.io/reference/helm)                                    | Deprecated | Ability to push and pull helm charts                         |
-| [S3 Protocol](https://canarychecker.io/reference/s3-protocol)                      | GA         | Ability to read/write/list objects on an S3 compatible object store |
+This is the current high-level inventory. See the [reference docs](https://canarychecker.io/reference) for full schemas and examples.
+
+| Category | Current checks |
+| --- | --- |
+| Network | [HTTP(s)](https://canarychecker.io/reference/http), [DNS](https://canarychecker.io/reference/dns), [ICMP](https://canarychecker.io/reference/icmp), [TCP](https://canarychecker.io/reference/tcp) |
+| Data sources | [Postgres, MySQL and SQL Server](https://canarychecker.io/reference/sql), [LDAP](https://canarychecker.io/reference/ldap), [MongoDB](https://canarychecker.io/reference/mongo), [Redis](https://canarychecker.io/reference/redis), [Prometheus](https://canarychecker.io/reference/prometheus), [Elasticsearch](https://canarychecker.io/reference/elasticsearch), OpenSearch |
+| Alerts and integrations | [Alertmanager](https://canarychecker.io/reference/alert-manager), [AWS CloudWatch](https://canarychecker.io/reference/aws-cloudwatch), Dynatrace, [Azure DevOps](https://canarychecker.io/reference/azure-devops), [PubSub](https://canarychecker.io/reference/pubsub), [webhooks](https://canarychecker.io/reference/webhook) |
+| Configuration and cloud | [AWS Config](https://canarychecker.io/reference/aws-config), [AWS Config Rule](https://canarychecker.io/reference/aws-config-rule), [Config DB / catalog](https://canarychecker.io/reference/catalog), [Kubernetes](https://canarychecker.io/reference/kubernetes), [Kubernetes Resource](https://canarychecker.io/reference/kubernetes-resource) |
+| Files and backups | [Folder](https://canarychecker.io/reference/folder) checks for local/NFS, S3, GCS, SFTP and SMB/CIFS; [S3 protocol](https://canarychecker.io/reference/s3-protocol); [GCP database backups](https://canarychecker.io/reference/gcs-database-backup); [Restic](https://canarychecker.io/reference/restic) |
+| Test runners and custom checks | [Exec](https://canarychecker.io/reference/exec), [JMeter](https://canarychecker.io/reference/jmeter), [JUnit / BYO](https://canarychecker.io/reference/junit), plus k6, Newman/Postman and Playwright via JUnit-producing containers |
+
+Legacy compatibility fields still exist in the CRD for `pod`, `namespace`, `docker`, `dockerPush`, `containerd`, `containerdPush`, `helm`, `github` and `gitProtocol`, but the runner reports them as removed. Use `kubernetesResource`, `kubernetes`, `exec`, `junit` or `webhook` checks for those workflows.
 
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md)
 
-Thank you to all our contributors !
+Thank you to all our contributors!
 
 <a href="https://github.com/flanksource/canary-checker/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=flanksource/canary-checker" />
@@ -348,6 +330,6 @@ Thank you to all our contributors !
 
 ## License
 
-Canary Checker core (the code in this repository) is licensed under [Apache 2.0](https://raw.githubusercontent.com/flanksource/canary-checker/main/LICENSE) and accepts contributions via GitHub pull requests after signing a CLA.
+Canary Checker core (the code in this repository) is licensed under [Apache 2.0](./LICENSE) and accepts contributions via GitHub pull requests after signing a CLA.
 
-The UI (Dashboard) is free to use with canary checker under a license exception of [Flanksource UI](https://github.com/flanksource/flanksource-ui/blob/main/LICENSE#L7)
+The UI (Dashboard) is free to use with Canary Checker under a license exception of [Flanksource UI](https://github.com/flanksource/flanksource-ui/blob/main/LICENSE#L7)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </div>
 
 ---
-Canary Checker is a Kubernetes-native platform for monitoring application and infrastructure health using both active synthetic checks and passive signal ingestion.
+Canary Checker is a Kubernetes-native platform for monitoring health across applications and infrastructure using both passive and active (synthetic) mechanisms.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -305,18 +305,55 @@ Your feedback is always welcome!
 
 ## Check Types
 
-This is the current high-level inventory. See the [reference docs](https://canarychecker.io/reference) for full schemas and examples.
-
-| Category | Current checks |
-| --- | --- |
-| Network | [HTTP(s)](https://canarychecker.io/reference/http), [DNS](https://canarychecker.io/reference/dns), [ICMP](https://canarychecker.io/reference/icmp), [TCP](https://canarychecker.io/reference/tcp) |
-| Data sources | [Postgres, MySQL and SQL Server](https://canarychecker.io/reference/sql), [LDAP](https://canarychecker.io/reference/ldap), [MongoDB](https://canarychecker.io/reference/mongo), [Redis](https://canarychecker.io/reference/redis), [Prometheus](https://canarychecker.io/reference/prometheus), [Elasticsearch](https://canarychecker.io/reference/elasticsearch), OpenSearch |
-| Alerts and integrations | [Alertmanager](https://canarychecker.io/reference/alert-manager), [AWS CloudWatch](https://canarychecker.io/reference/aws-cloudwatch), Dynatrace, [Azure DevOps](https://canarychecker.io/reference/azure-devops), [PubSub](https://canarychecker.io/reference/pubsub), [webhooks](https://canarychecker.io/reference/webhook) |
-| Configuration and cloud | [AWS Config](https://canarychecker.io/reference/aws-config), [AWS Config Rule](https://canarychecker.io/reference/aws-config-rule), [Config DB / catalog](https://canarychecker.io/reference/catalog), [Kubernetes](https://canarychecker.io/reference/kubernetes), [Kubernetes Resource](https://canarychecker.io/reference/kubernetes-resource) |
-| Files and backups | [Folder](https://canarychecker.io/reference/folder) checks for local/NFS, S3, GCS, SFTP and SMB/CIFS; [S3 protocol](https://canarychecker.io/reference/s3-protocol); [GCP database backups](https://canarychecker.io/reference/gcs-database-backup); [Restic](https://canarychecker.io/reference/restic) |
-| Test runners and custom checks | [Exec](https://canarychecker.io/reference/exec), [JMeter](https://canarychecker.io/reference/jmeter), [JUnit / BYO](https://canarychecker.io/reference/junit), plus k6, Newman/Postman and Playwright via JUnit-producing containers |
-
-Legacy compatibility fields still exist in the CRD for `pod`, `namespace`, `docker`, `dockerPush`, `containerd`, `containerdPush`, `helm`, `github` and `gitProtocol`, but the runner reports them as removed. Use `kubernetesResource`, `kubernetes`, `exec`, `junit` or `webhook` checks for those workflows.
+| Protocol                                                     | Status     | Checks                                                       |
+| ------------------------------------------------------------ | ---------- | ------------------------------------------------------------ |
+| [HTTP(s)](https://canarychecker.io/reference/http)           | GA         | Response body, headers and duration                          |
+| [DNS](https://canarychecker.io/reference/dns)                | GA         | Response and duration                                        |
+| [Ping/ICMP](https://canarychecker.io/reference/icmp)         | GA         | Duration and packet loss                                     |
+| [TCP](https://canarychecker.io/reference/tcp)                | GA         | Port is open and connectable                                 |
+| **Data Sources**                                             |            |                                                              |
+| [SQL](https://canarychecker.io/reference/sql) (MySQL, Postgres, SQL Server) | GA | Ability to login, results, duration, health exposed via stored procedures |
+| [LDAP](https://canarychecker.io/reference/ldap)              | GA         | Ability to login, response time                              |
+| [Elasticsearch](https://canarychecker.io/reference/elasticsearch) / OpenSearch | GA | Ability to login, response time, size of search results      |
+| [MongoDB](https://canarychecker.io/reference/mongo)          | Beta       | Ability to login, results, duration                          |
+| [Redis](https://canarychecker.io/reference/redis)            | GA         | Ability to login, results, duration                          |
+| [Prometheus](https://canarychecker.io/reference/prometheus)  | GA         | Ability to login, query results and duration                  |
+| **Alerts / Events**                                          |            |                                                              |
+| [Prometheus Alertmanager](https://canarychecker.io/reference/alert-manager) | GA | Pending and firing alerts                                    |
+| [AWS CloudWatch Alarms](https://canarychecker.io/reference/aws-cloudwatch) | GA | Pending and firing alarms                                    |
+| [Dynatrace Problems](./fixtures/external/dynatrace.yaml)     | Beta       | Problems detected                                            |
+| [PubSub](https://canarychecker.io/reference/pubsub)          | Beta       | Messages received from a Pub/Sub subscription                |
+| [Webhook](https://canarychecker.io/reference/webhook)        | GA         | Passive checks created or updated by HTTP POST requests      |
+| **DevOps**                                                   |            |                                                              |
+| [Azure DevOps](https://canarychecker.io/reference/azure-devops) | Beta    | Pipeline status and duration                                 |
+| Git / GitProtocol                                            | Removed    | Use `exec`, `junit` or `webhook` checks instead              |
+| **Integration Testing**                                      |            |                                                              |
+| [Exec](https://canarychecker.io/reference/exec)              | GA         | Run scripts or commands                                      |
+| [JMeter](https://canarychecker.io/reference/jmeter)          | Beta       | Runs and checks the result of a JMeter test                  |
+| [JUnit / BYO](https://canarychecker.io/reference/junit)      | Beta       | Run a pod that saves JUnit test results                      |
+| [K6](https://canarychecker.io/examples/k6)                   | Beta       | Runs k6 tests that export JUnit via a container              |
+| [Newman](https://canarychecker.io/examples/newman)           | Beta       | Runs Newman / Postman tests that export JUnit via a container |
+| [Playwright](https://canarychecker.io/examples/Playwright)   | Beta       | Runs Playwright tests that export JUnit via a container      |
+| **File Systems / Batch**                                     |            |                                                              |
+| [Local Disk / NFS](https://canarychecker.io/reference/folder) | GA        | Check folders for files that are too few/many, too old/new, too small/large |
+| [S3](https://canarychecker.io/reference/folder#s3)           | GA         | Check contents of AWS S3 buckets                             |
+| [GCS](https://canarychecker.io/reference/folder#gcs)         | GA         | Check contents of Google Cloud Storage buckets               |
+| [SFTP](https://canarychecker.io/reference/folder#sftp)       | GA         | Check contents of folders over SFTP                          |
+| [SMB / CIFS](https://canarychecker.io/reference/folder#smb)  | GA         | Check contents of folders over SMB/CIFS                      |
+| **Config**                                                   |            |                                                              |
+| [AWS Config](https://canarychecker.io/reference/aws-config)  | GA         | Query AWS Config using SQL                                   |
+| [AWS Config Rule](https://canarychecker.io/reference/aws-config-rule) | GA  | AWS Config rules that are firing, custom AWS Config queries  |
+| [Config DB / Catalog](https://canarychecker.io/reference/catalog) | GA    | Custom config queries for Mission Control Config DB          |
+| [Kubernetes](https://canarychecker.io/reference/kubernetes)  | GA         | Kubernetes resources that are missing or in a non-ready state |
+| [Kubernetes Resource](https://canarychecker.io/reference/kubernetes-resource) | GA | Create temporary resources, run nested checks and clean up   |
+| **Backups**                                                  |            |                                                              |
+| [GCP Databases](https://canarychecker.io/reference/gcs-database-backup) | GA | Backup freshness                                             |
+| [Restic](https://canarychecker.io/reference/restic)          | Beta       | Backup freshness and integrity                               |
+| **Infrastructure**                                           |            |                                                              |
+| [S3 Protocol](https://canarychecker.io/reference/s3-protocol) | GA        | Ability to read/write/list objects on an S3 compatible object store |
+| Pod / Namespace                                              | Removed    | Use `kubernetesResource` or `kubernetes` checks instead      |
+| Docker / Containerd                                          | Removed    | Use `kubernetesResource` or `exec` checks instead            |
+| Helm                                                         | Removed    | Use `kubernetesResource` or `exec` checks instead            |
 
 ## Contributing
 


### PR DESCRIPTION
Refresh the README to match the current Canary Checker behavior.

Replace deprecated `spec.interval` examples with `spec.schedule`, fix invalid snippets, and update the infrastructure example to use `kubernetesResource`.

Condense the check inventory so current check types are listed without duplicating the docs site, and call out legacy compatibility fields that now report as removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed the product overview and getting-started guidance with updated terminology and clearer examples.
  * Updated Helm and `kubectl` examples to use the current `schedule`-based configuration format and matching output columns.
  * Revised multiple use-case and check examples, including Kubernetes resource-based testing patterns and updated Prometheus/platform-ready snippets.
  * Reworked dashboard/help, check type summaries, and contributing/license text for clarity and compatibility notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->