### PR TITLE
feat(chart): add optional startupProbe support

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -220,6 +220,10 @@ spec:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- if .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- end }}
       {{- with .Values.extra }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -414,6 +414,9 @@
     "readinessProbe": {
       "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
     },
+    "startupProbe": {
+      "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
+    },
     "replicas": {
       "default": 1,
       "title": "replicas"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -669,3 +669,12 @@ readinessProbe:
   httpGet:
     path: /health
     port: 8080
+
+# @schema
+# required: false
+# $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe
+# @schema
+# -- Optional startup probe. When set, liveness and readiness probes are disabled
+# until this probe succeeds. Useful when init takes longer than the default liveness
+# window (e.g. embedded-postgres on low-CPU nodes).
+startupProbe: {}


### PR DESCRIPTION
## Summary

Adds an optional `startupProbe` field to the chart values, rendered in the
Deployment/StatefulSet spec alongside the existing `livenessProbe` and `readinessProbe`.

Default is `{}` (empty map → falsy in Go templates), so no probe is added unless
explicitly configured. Zero behaviour change for existing deployments.

## Usage

```yaml
startupProbe:
  httpGet:
    path: /health
    port: 8080
  failureThreshold: 30
  periodSeconds: 10
```

Files changed

- chart/templates/deployment.yaml — {{- if .Values.startupProbe }} conditional block after readinessProbe
- chart/values.yaml — startupProbe: {} with @schema annotation and $ref to k8s Probe type
- chart/values.schema.json — startupProbe property alongside livenessProbe/readinessProbe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a startup probe for the main container.
  * Included the new probe option in chart configuration and validation.
  * When enabled, startup checks now run before liveness and readiness checks take effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->