### PR TITLE
feat(chart): add extra containers

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -70,6 +70,8 @@ Kubernetes native, multi-tenant synthetic monitoring system
 | dockerSocket | bool | `false` |  |
 | extra | object | `{}` |  |
 | extraArgs | string | `nil` |  |
+| extraContainers | list | `[]` | Additional sidecar containers to add to the pod |
+| extraInitContainers | list | `[]` | Additional init containers to add to the pod |
 | flanksource-ui.backendURL | string | `"http://canary-checker:8080"` |  |
 | flanksource-ui.enabled | bool | `true` |  |
 | flanksource-ui.image.name | string | `"{{.Values.global.imagePrefix}}/canary-checker-ui"` |  |

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -75,8 +75,9 @@ spec:
           - name: net.ipv4.ping_group_range
             value: "0 2147483647"
         {{- end }}
-      {{- if eq .Values.db.embedded.persist true }}
+      {{- if or (eq .Values.db.embedded.persist true) .Values.extraInitContainers }}
       initContainers:
+        {{- if eq .Values.db.embedded.persist true }}
         - image: busybox
           name: postgres-perms
           command:
@@ -86,6 +87,10 @@ spec:
           volumeMounts:
             - mountPath: /opt/database
               name: canarychecker-database
+        {{- end }}
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end}}
       containers:
         - name: {{ include "canary-checker.name" . }}
@@ -220,6 +225,9 @@ spec:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.extra }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -174,6 +174,22 @@
       "default": "",
       "title": "extraArgs"
     },
+    "extraContainers": {
+      "description": "Additional sidecar containers to add to the pod",
+      "items": {
+        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
+      },
+      "title": "extraContainers",
+      "type": "array"
+    },
+    "extraInitContainers": {
+      "description": "Additional init containers to add to the pod",
+      "items": {
+        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
+      },
+      "title": "extraInitContainers",
+      "type": "array"
+    },
     "flanksource-ui": {
       "$ref": "https://raw.githubusercontent.com/flanksource/flanksource-ui/main/chart/values.schema.deref.json",
       "additionalProperties": true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -607,6 +607,24 @@ extraArgs:
 extra: {}
 
 # @schema
+# required: false
+# type: array
+# items:
+#   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container
+# @schema
+# -- Additional sidecar containers to add to the pod
+extraContainers: []
+
+# @schema
+# required: false
+# type: array
+# items:
+#   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container
+# @schema
+# -- Additional init containers to add to the pod
+extraInitContainers: []
+
+# @schema
 # additionalProperties: true
 # required: false
 # @schema


### PR DESCRIPTION
## Summary
Adds an optional `extraContainers` and `extraInitContainers` in the helm chart, to support sidecar containers. Default is empty.

Addresses issue: #3054 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Helm chart configuration options for injecting additional sidecar containers and init containers into application pods.
  - Added schema validation and documentation for the new container configuration options.
  - Additional init containers are supported alongside embedded database initialization when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->