### PR TITLE
fix: decode check namespace JSON strings

### DIFF
--- a/api/v1/common.go
+++ b/api/v1/common.go
@@ -455,7 +455,11 @@ func (d Description) GetNamespace() string {
 		return ""
 	}
 	if !strings.HasPrefix(s, "{") {
-		return s
+		var namespace string
+		if err := json.Unmarshal(d.Namespace, &namespace); err != nil {
+			return ""
+		}
+		return namespace
 	}
 	var r types.ResourceSelector
 	if err := json.Unmarshal(d.Namespace, &r); err != nil {

--- a/api/v1/common.go
+++ b/api/v1/common.go
@@ -450,7 +450,7 @@ func (d Description) GetHash() string {
 }
 
 func (d Description) GetNamespace() string {
-	s := string(d.Namespace)
+	s := strings.TrimSpace(string(d.Namespace))
 	if s == "" || s == "{}" {
 		return ""
 	}

--- a/api/v1/common_test.go
+++ b/api/v1/common_test.go
@@ -17,6 +17,7 @@ func TestDescriptionGetNamespace(t *testing.T) {
 		{name: "empty string", namespace: `""`},
 		{name: "escaped string", namespace: `"netpol\u002dprobe-a"`, want: "netpol-probe-a"},
 		{name: "legacy selector", namespace: `{"name":"netpol-probe-a"}`, want: "netpol-probe-a"},
+		{name: "legacy selector with whitespace", namespace: " \n\t{\"name\":\"netpol-probe-a\"}", want: "netpol-probe-a"},
 		{name: "invalid JSON", namespace: `"unterminated`},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/api/v1/common_test.go
+++ b/api/v1/common_test.go
@@ -1,0 +1,29 @@
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDescriptionGetNamespace(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		namespace string
+		want      string
+	}{
+		{name: "omitted"},
+		{name: "empty object", namespace: `{}`},
+		{name: "string", namespace: `"netpol-probe-a"`, want: "netpol-probe-a"},
+		{name: "empty string", namespace: `""`},
+		{name: "escaped string", namespace: `"netpol\u002dprobe-a"`, want: "netpol-probe-a"},
+		{name: "legacy selector", namespace: `{"name":"netpol-probe-a"}`, want: "netpol-probe-a"},
+		{name: "invalid JSON", namespace: `"unterminated`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			d := Description{Namespace: json.RawMessage(tt.namespace)}
+			if got := d.GetNamespace(); got != tt.want {
+				t.Errorf("GetNamespace() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3066.

Explicit check namespaces are stored as raw JSON. `GetNamespace()` converted those bytes directly to text, retaining JSON quotes in the namespace passed to persistence. Inherited Canary namespaces are plain strings, so the same namespace could appear as both `netpol-probe-a` and `"netpol-probe-a"` in separate tabs.

## How the namespace field got here

The shared Go field did **not** originally change from a selector to a string. Two different fields used the same YAML/JSON key:

1. **September 29, 2021 — [add kubernetes check](https://github.com/flanksource/canary-checker/commit/6b899eef02e4499472b9e4bba053f08d4b54e3f6).** `KubernetesCheck` introduced its own object-valued `namespace` selector. This was the `kubernetes` check, not `kubernetesResource`.

   ```go
   type KubernetesCheck struct {
       Description `yaml:",inline" json:",inline"`
       Namespace ResourceSelector `yaml:"namespace,omitempty" json:"namespace,omitempty"`
   }
   ```

2. **November 9, 2023 — [namespace on checks](https://github.com/flanksource/canary-checker/commit/18b231591fd747c966a1e51d2536d28687fdc2b5).** A shared string-valued namespace was added to the embedded `Description` for assigning checks to namespaces. The HTTP-specific namespace field was removed in favor of this shared field. The Kubernetes selector and shared field now both used `namespace`.

   ```go
   type Description struct {
       Namespace string `yaml:"namespace,omitempty" json:"namespace,omitempty"`
   }
   ```

3. **December 29, 2023 — [fix conflicting namespace selector](https://github.com/flanksource/canary-checker/commit/e34968108258040c0ff2f3e31707015dca672942).** The Kubernetes selector's serialized key was renamed to `namespaceSelector`, separating resource selection from the check's namespace. Old configurations could still have an object under `namespace`, which now mapped to the shared string field.

   ```diff
   - Namespace ResourceSelector `yaml:"namespace,omitempty" json:"namespace,omitempty"`
   + Namespace ResourceSelector `yaml:"namespaceSelector,omitempty" json:"namespaceSelector,omitempty"`
   ```

4. **January 1, 2024 — [destination namespace type change backwards compatibility](https://github.com/flanksource/canary-checker/commit/25ed51b0269912dc9a25b65f307b5b1a94708f8a).** The shared field changed from `string` to `json.RawMessage` to accept legacy objects as well as strings. The getter introduced `string(d.Namespace)` and returned it directly for non-object values, introducing the quoted-string bug.

   ```diff
   - Namespace string
   + Namespace json.RawMessage
   ```

5. **January 2, 2024 — [lookup bug in namespace selector](https://github.com/flanksource/canary-checker/commit/3ed992612a72546a9b37943101308835764a4231).** Object detection was corrected from the prefix `"{}"` to `"{"`, and successful object decoding was corrected to return `r.Name`. The string branch still returned raw JSON without decoding it.

6. **This PR:** Decode the string branch too. Keep `RawMessage` so legacy objects remain accepted; their existing behavior is to return the selector's name, not restore the former resource-selection semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved namespace handling when processing descriptions encoded as JSON.
  - Surrounding whitespace is now handled correctly for empty namespaces, JSON strings, and legacy selector formats.
  - Preserved support for escaped strings, omitted namespaces, and legacy namespace selector objects.
  - Invalid namespace values continue to resolve safely without disrupting description processing.
  - Added coverage for common namespace formats and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->