### PR TITLE
perf(ci): restore Go caches and remove duplicate build work

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,12 @@ jobs:
           - { arch: arm64, runner: ubuntu-24.04-arm }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: 1.26.x
+          cache-dependency-path: '**/go.sum'
       - name: Build Linux Binary
-        run: make linux compress
+        run: make linux-${{ matrix.arch }} compress
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e-operator.yml
+++ b/.github/workflows/e2e-operator.yml
@@ -24,23 +24,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.26.x
-
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            .bin
-          key: cache-${{ hashFiles('**/go.sum') }}-${{ hashFiles('.bin/*') }}
-          restore-keys: |
-            cache-
+          cache-dependency-path: '**/go.sum'
 
       - run: make bin
 

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -10,20 +10,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.26.x
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: cache-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            cache-
+          cache-dependency-path: '**/go.sum'
       - name: Test fuzz seed corpus
         run: go test ./pkg -run=FuzzParseConfig -count=1
       - name: Test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.26.x
+          cache-dependency-path: '**/go.sum'
       - run: make resources
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
@@ -32,7 +33,6 @@ jobs:
         env:
           CI: false
         run: |
-          make resources
           git checkout fixtures/datasources/go.*
           git diff
           changed_files=$(git status -s)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,12 +51,13 @@ jobs:
           # - restic
     runs-on: ${{ matrix.suite.on }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.26.x
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          cache-dependency-path: '**/go.sum'
       - run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.2
       - run: make bin
 

--- a/Makefile
+++ b/Makefile
@@ -157,10 +157,11 @@ compress:
 compress-build:
 	upx -5 ./$(RELEASE_DIR)/$(NAME) ./$(RELEASE_DIR)/$(NAME).test
 
-.PHONY: linux
-linux:
-	GOOS=linux GOARCH=amd64 go build  -o ./$(RELEASE_DIR)/$(NAME)_linux_amd64 $(LD_FLAGS)  main.go
-	GOOS=linux GOARCH=arm64 go build  -o ./$(RELEASE_DIR)/$(NAME)_linux_arm64 $(LD_FLAGS)  main.go
+.PHONY: linux linux-amd64 linux-arm64
+linux: linux-amd64 linux-arm64
+
+linux-amd64 linux-arm64: linux-%:
+	GOOS=linux GOARCH=$* go build -o ./$(RELEASE_DIR)/$(NAME)_linux_$* $(LD_FLAGS) main.go
 
 .PHONY: darwin
 darwin:


### PR DESCRIPTION
Go cache restoration ran before checkout, so setup-go could not find dependency files. Manual caches overlapped it, both binary jobs compiled both architectures, and lint generated resources twice.

- Check out first and use setup-go caches keyed by OS, architecture, Go version and nested module sums; stop caching tool binaries.
- Build only the assigned Linux architecture while preserving the dual-architecture release target and compression; generate lint resources once and retain the generated-file diff check.
- Measured baseline: binary steps 415s/414s; lint generation 266s plus a repeated generation/check step of 35s. Savings remain unmeasured.
- Independent base: master. The shared E2E binary PR touches an adjacent setup block; when reconciling it, retain checkout-before-Go/cache settings and replace the per-suite compiler install with artifact download.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Linux release builds now produce architecture-specific binaries for AMD64 and ARM64.
  - Linux binaries are compressed as part of the release build process.

- **Chores**
  - Automated builds and tests now use consistent Go dependency caching.
  - Continuous integration checks now follow a more consistent setup sequence, improving reliability.
  - Generated-resource validation now uses the dedicated resource-generation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->