### PR TITLE
perf(ci): cancel superseded pull request workflow runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ on: pull_request
 name: Build
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   docker:
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/e2e-operator.yml
+++ b/.github/workflows/e2e-operator.yml
@@ -20,6 +20,9 @@ on:
 name: Operator E2E Test
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -6,6 +6,9 @@ permissions:
   issues: read
   pull-requests: read
 name: Go Test
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   merge_group:
 permissions: read-all
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   golangci:
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
 name: Test
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   # build:
   #   runs-on: ubuntu-latest


### PR DESCRIPTION
New commits currently leave obsolete PR workflow runs consuming runners alongside their replacements.

- Add concurrency groups scoped to workflow, event and PR across all seven PR workflows.
- Cancel in-progress runs only for pull_request events; give other events unique run-ID groups so unrelated branches, tags, schedules and merge groups remain independent.
- Independent base: master; no dependency on the other workflow-speed PRs. Runner-time savings depend on commit frequency and have not been measured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated workflow management by grouping related runs and canceling outdated in-progress runs for pull requests.
  - Reduced redundant CI, testing, linting, security analysis, and deployment checks, helping new changes receive feedback more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->