### PR TITLE
perf(ci): share one compiled binary across E2E suites

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,34 +13,27 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
-  # build:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Install Go
-  #       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-  #       with:
-  #         go-version: 1.26.x
-  #     - name: Checkout code
-  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-  #     - uses:actions/cache@v4.2.0
-  #       with:
-  #         path: |
-  #           ~/go/pkg/mod
-  #           ~/.cache/go-build
-  #           .bin
-  #         key: cache-${{ hashFiles('**/go.sum') }}-${{ hashFiles('.bin/*') }}
-  #         restore-keys: |
-  #           cache-
-  #     - run: make  build
-  #     - run: cd test && make build
-  #     - run: make compress-build
-  #     - uses: actions/upload-artifact@v3
-  #       with:
-  #         name: bin
-  #         path: |
-  #           .bin/canary-checker
-  #           .bin/canary-checker.test
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: 1.26.x
+          cache-dependency-path: '**/go.sum'
+      - run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.2
+      - run: make -C test build
+      - name: Upload E2E test binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-linux-amd64
+          path: test/test.test
+          if-no-files-found: error
+          retention-days: 1
   test:
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -61,7 +54,12 @@ jobs:
         with:
           go-version: 1.26.x
           cache-dependency-path: '**/go.sum'
-      - run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.2
+      - name: Download E2E test binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: e2e-linux-amd64
+          path: test
+      - run: chmod +x test/test.test
       - run: make bin
 
       - name: Set up Kind cluster


### PR DESCRIPTION
The five E2E suites independently compile the same Go package. Build it once with the existing Makefile and distribute a same-run Linux amd64 artifact to the unchanged suite matrix.

- Restore executable permission after download and retain runtime Go setup for fixture preparation.
- Measured baseline: the minimal suite execution step took 367s, largely compilation. Four duplicate compilations are removed, but producer-job and artifact-transfer latency mean wall-clock savings remain unmeasured.
- Independent base: master; no runtime dependency on #3069. Its adjacent setup hunk can conflict after one lands: retain checkout-before-Go/cache settings from #3069 and artifact download from this PR.