### PR TITLE
perf(ci): isolate Docker caches and trim exported compiler data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,8 @@ jobs:
           platforms: linux/${{ matrix.arch }}
           load: true
           tags: canary-checker:${{ matrix.variant }}-${{ matrix.arch }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=image-${{ matrix.variant }}-${{ matrix.arch }}
+          cache-to: type=gha,scope=image-${{ matrix.variant }}-${{ matrix.arch }},mode=max
       - name: Run Container Self-Test
         run: |
           docker run --rm \

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -37,8 +37,8 @@ jobs:
           file: ./build/full/Dockerfile
           push: true
           tags: kind-registry:5000/flanksource/canary-checker:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=helm-full-amd64
+          cache-to: type=gha,scope=helm-full-amd64,mode=max
         env:
           KIND_REGISTRY: kind-registry:5000
 

--- a/build/full/Dockerfile
+++ b/build/full/Dockerfile
@@ -13,7 +13,9 @@ COPY go.sum /app/go.sum
 RUN go mod download
 
 COPY ./ ./
-RUN OS=${TARGETOS} ARCH=${TARGETARCH} make build
+# Keep compiler scratch data out of exported layers; retain the module download layer.
+RUN --mount=type=cache,target=/root/.cache/go-build,id=go-1.26.1-${TARGETOS}-${TARGETARCH} \
+    OS=${TARGETOS} ARCH=${TARGETARCH} make build
 
 FROM flanksource/base-image-canary-checker:0.7.1@sha256:010f16e33084db3b94a4b741b5c895fa1274a3b5864bdc05b924940289c456cc
 ARG TARGETARCH

--- a/build/minimal/Dockerfile
+++ b/build/minimal/Dockerfile
@@ -13,7 +13,9 @@ COPY go.sum /app/go.sum
 RUN go mod download
 
 COPY ./ ./
-RUN OS=${TARGETOS} ARCH=${TARGETARCH} make build
+# Keep compiler scratch data out of exported layers; retain the module download layer.
+RUN --mount=type=cache,target=/root/.cache/go-build,id=go-1.26.1-${TARGETOS}-${TARGETARCH} \
+    OS=${TARGETOS} ARCH=${TARGETARCH} make build
 
 FROM flanksource/base-image:0.7.1@sha256:5e819e83199855d20ba5b988e8a6f369c6f4332fa6f07c184c99838d06a77cc8
 ARG TARGETARCH

--- a/build/slim/Dockerfile
+++ b/build/slim/Dockerfile
@@ -13,7 +13,9 @@ COPY go.sum /app/go.sum
 RUN go mod download
 
 COPY ./ ./
-RUN OS=${TARGETOS} ARCH=${TARGETARCH} make build
+# Keep compiler scratch data out of exported layers; retain the module download layer.
+RUN --mount=type=cache,target=/root/.cache/go-build,id=go-1.26.1-${TARGETOS}-${TARGETARCH} \
+    OS=${TARGETOS} ARCH=${TARGETARCH} make build
 
 FROM ubuntu:noble@sha256:c35e29c9450151419d9448b0fd75374fec4fff364a27f176fb458d472dfc9e54 AS base
 WORKDIR /app


### PR DESCRIPTION
Concurrent image builds currently overwrite the same GHA cache scope and export compiler scratch data inside their build layers.

- Scope caches by image variant/architecture, with a separate Helm scope while that image build remains independent; keep all image check locations unchanged.
- Mount Go compiler scratch outside exported layers while retaining mode=max dependency-layer reuse. Cache-mount contents do not persist across hosted runners.
- Measured baseline: full amd64 cache export took 393.9s of an 819s image step; Helm export took 351s of 710s. Smaller exports are expected, but savings remain unmeasured.
- Independent base: master; image deduplication and readiness polling are intentionally excluded.