### PR TITLE
perf(ci): replace the Helm readiness sleep with polling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { arch: amd64, runner: ubuntu-latest, variant: full }
+          # Helm Test builds and self-tests full/amd64 using the same image it deploys.
           - { arch: amd64, runner: ubuntu-latest, variant: slim }
           - { arch: arm64, runner: ubuntu-24.04-arm, variant: full }
           - { arch: arm64, runner: ubuntu-24.04-arm, variant: slim }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 on: pull_request
-name: Build
+name: Build & Smoke Test
 permissions: read-all
 
 concurrency:
@@ -32,7 +32,7 @@ jobs:
           tags: canary-checker:${{ matrix.variant }}-${{ matrix.arch }}
           cache-from: type=gha,scope=image-${{ matrix.variant }}-${{ matrix.arch }}
           cache-to: type=gha,scope=image-${{ matrix.variant }}-${{ matrix.arch }},mode=max
-      - name: Run Container Self-Test
+      - name: Run Container Smoke Test
         run: |
           docker run --rm \
             -v ${{ github.workspace }}/fixtures/selftest:/fixtures:ro \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Helm Test builds and self-tests full/amd64 using the same image it deploys.
+          - { arch: amd64, runner: ubuntu-latest, variant: full }
           - { arch: amd64, runner: ubuntu-latest, variant: slim }
           - { arch: arm64, runner: ubuntu-24.04-arm, variant: full }
           - { arch: arm64, runner: ubuntu-24.04-arm, variant: slim }

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -39,12 +39,21 @@ jobs:
         with:
           context: .
           file: ./build/full/Dockerfile
+          platforms: linux/amd64
           push: true
+          load: true
           tags: kind-registry:5000/flanksource/canary-checker:latest
           cache-from: type=gha,scope=helm-full-amd64
           cache-to: type=gha,scope=helm-full-amd64,mode=max
         env:
           KIND_REGISTRY: kind-registry:5000
+
+      - name: Run Container Self-Test
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}/fixtures/selftest:/fixtures:ro \
+            kind-registry:5000/flanksource/canary-checker:latest \
+            run /fixtures/container-selftest-full.yaml
 
       - name: Update canary-checker image in helm chart
         uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c # v4.53.2
@@ -64,7 +73,7 @@ jobs:
       - name: Install helm chart
         run: "helm install canary-checker canary-checker-1.0.0.tgz -n canary-checker --create-namespace"
 
-      - name: Wait for 30 seconds
+      - name: Wait for deployment rollout
         run: "kubectl rollout status deploy/canary-checker -n canary-checker --timeout 5m"
 
       - name: Check canary-checker pods

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -39,21 +39,12 @@ jobs:
         with:
           context: .
           file: ./build/full/Dockerfile
-          platforms: linux/amd64
           push: true
-          load: true
           tags: kind-registry:5000/flanksource/canary-checker:latest
           cache-from: type=gha,scope=helm-full-amd64
           cache-to: type=gha,scope=helm-full-amd64,mode=max
         env:
           KIND_REGISTRY: kind-registry:5000
-
-      - name: Run Container Self-Test
-        run: |
-          docker run --rm \
-            -v ${{ github.workspace }}/fixtures/selftest:/fixtures:ro \
-            kind-registry:5000/flanksource/canary-checker:latest \
-            run /fixtures/container-selftest-full.yaml
 
       - name: Update canary-checker image in helm chart
         uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c # v4.53.2

--- a/chart/test.sh
+++ b/chart/test.sh
@@ -2,7 +2,7 @@
 
 ns="-n $1"
 
-kubectl apply -f fixtures/minimal/exec_pass.yaml $ns
+kubectl apply -f fixtures/minimal/exec_pass.yaml $ns || exit 1
 
 kubectl get pods --all-namespaces
 
@@ -22,25 +22,43 @@ kubectl port-forward $ns  svc/canary-checker $PORT:8080 &
 PID=$!
 function cleanup {
   echo "Cleaning up..."
-  kill $PID
+  kill "$PID" 2>/dev/null || true
+  wait "$PID" 2>/dev/null || true
 }
 
 trap cleanup EXIT
 
-sleep 60
-
-status=$(kubectl get  $ns canaries.canaries.flanksource.com exec-pass -o yaml | yq .status.status)
+deadline=$((SECONDS + 60))
+ready=false
+while (( SECONDS < deadline )); do
+  if ! kill -0 "$PID" 2>/dev/null; then
+    echo "Port-forward exited before readiness"
+    break
+  fi
+  status=$(kubectl get $ns canaries.canaries.flanksource.com exec-pass --request-timeout=5s -o jsonpath='{.status.status}')
+  if [[ "$status" == "Passed" ]] &&
+    curl --silent --show-error --fail --max-time 2 "http://localhost:$PORT/health" &&
+    curl --silent --show-error --fail --max-time 2 "http://localhost:$PORT/db/checks"; then
+    ready=true
+    break
+  fi
+  sleep 2
+done
 echo "Status=$status"
-if [[ $status != "Passed" ]]; then
+if [[ "$ready" != "true" ]]; then
+  echo "Timed out waiting for Passed status, health, and database readiness"
+  kubectl get $ns canaries.canaries.flanksource.com exec-pass --request-timeout=5s -o yaml
+  kubectl get pods $ns --request-timeout=5s
+  kubectl logs $ns deploy/canary-checker --tail=100 --request-timeout=5s
   exit 1
 fi
 
-if ! curl -vv --fail "http://localhost:$PORT/health"; then
+if ! curl -vv --fail --max-time 5 "http://localhost:$PORT/health"; then
   echo "Call to health failed"
   exit 1
 fi
 
-if ! curl -vv --fail "http://localhost:$PORT/db/checks"; then
+if ! curl -vv --fail --max-time 5 "http://localhost:$PORT/db/checks"; then
   # "we don't really care about the results as long as it is sucessful"
   echo "Call to postgrest failed"
   exit 1


### PR DESCRIPTION
The Helm validation script always waits 60 seconds, even when the deployment is already ready.

- Poll Canary Passed status and the health/database endpoints, with bounded requests and early completion when ready.
- Fail immediately if fixture application fails; include timeout diagnostics and clean up the port-forward process.
- Rename the rollout step to describe its existing behavior instead of suggesting a fixed delay.
- Keep all six image combinations and their container validation in Build. Image deduplication and validation relocation have been withdrawn; existing check names and branch-protection requirements are unchanged.

The former fixed delay was 60 seconds. Actual time saved depends on readiness and has not been measured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment testing reliability by waiting for rollout and readiness conditions instead of relying on fixed delays.
  * Added clearer diagnostic output when deployment checks time out.
  * Ensured test failures stop execution promptly and cleanup completes reliably.

* **Chores**
  * Clarified build, smoke test, and deployment workflow labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->