### PR TITLE
perf(ci): isolate coverage caches and remove redundant work

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -16,12 +16,27 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Go
+        id: go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.26.x
-          cache-dependency-path: '**/go.sum'
-      - name: Test fuzz seed corpus
-        run: go test ./pkg -run=FuzzParseConfig -count=1
+          cache: false
+      - name: Locate Go caches
+        id: go-cache
+        run: |
+          echo "build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "modules=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+          echo "image=$ImageOS" >> "$GITHUB_OUTPUT"
+      - name: Cache coverage-test builds and modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ${{ steps.go-cache.outputs.build }}
+            ${{ steps.go-cache.outputs.modules }}
+          # Caches are immutable: refresh on source changes, reusing compatible prior builds.
+          key: go-test-cover-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-cache.outputs.image }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            go-test-cover-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-cache.outputs.image }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('**/go.sum') }}-
       - name: Test
         run: make test
       - name: Publish Unit Test Results

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ all: manager
 
 .PHONY: test
 test: manifests generate fmt ginkgo
+	# Recursive Ginkgo also runs Go fuzz seeds (including FuzzParseConfig) in the coverage binaries.
 	ginkgo -vv -r  --cover  --keep-going --junit-report junit-report.xml --
 
 .PHONY: fuzz

--- a/pkg/api/suite_test.go
+++ b/pkg/api/suite_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flanksource/canary-checker/pkg/echo"
 	"github.com/flanksource/canary-checker/pkg/utils"
 	"github.com/flanksource/commons/logger"
+	"github.com/flanksource/commons/properties"
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/tests/setup"
 	echov4 "github.com/labstack/echo/v4"
@@ -25,6 +26,11 @@ var (
 )
 
 func TestAPI(t *testing.T) {
+	// Direct job runs should not wait for production scheduling jitter.
+	previous := properties.Get("job.jitter.disable")
+	properties.Set("job.jitter.disable", true)
+	t.Cleanup(func() { properties.Set("job.jitter.disable", previous) })
+
 	RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "API")
 }

--- a/pkg/jobs/canary/suite_test.go
+++ b/pkg/jobs/canary/suite_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flanksource/canary-checker/pkg/cache"
 	"github.com/flanksource/canary-checker/pkg/utils"
 	"github.com/flanksource/commons/logger"
+	"github.com/flanksource/commons/properties"
 	dutyContext "github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/tests/setup"
 	"github.com/labstack/echo/v4"
@@ -26,6 +27,11 @@ var (
 )
 
 func TestCanaryJobs(t *testing.T) {
+	// Direct job runs should not wait for production scheduling jitter.
+	previous := properties.Get("job.jitter.disable")
+	properties.Set("job.jitter.disable", true)
+	t.Cleanup(func() { properties.Set("job.jitter.disable", previous) })
+
 	RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "Canary Job")
 }

--- a/pkg/topology/suite_test.go
+++ b/pkg/topology/suite_test.go
@@ -3,6 +3,7 @@ package topology
 import (
 	"testing"
 
+	"github.com/flanksource/commons/properties"
 	dutyContext "github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/job"
 	"github.com/flanksource/duty/models"
@@ -30,6 +31,11 @@ func expectJobToPass(j *job.Job) {
 }
 
 func TestTopologyJobs(t *testing.T) {
+	// Direct job runs should not wait for production scheduling jitter.
+	previous := properties.Get("job.jitter.disable")
+	properties.Set("job.jitter.disable", true)
+	t.Cleanup(func() { properties.Set("job.jitter.disable", previous) })
+
 	RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "Topology")
 }


### PR DESCRIPTION
The Go CI investigation found competing cache writers, duplicate seed compilation, and production scheduling delays.

- E2E saved the shared immutable cache first, excluding later coverage artifacts. Give coverage builds a separate platform/Go/dependency key, refreshed per source revision with compatible fallback reuse.
- Remove the standalone noncoverage fuzz-seed invocation; recursive Ginkgo already executes the same corpus with coverage.
- Disable schedule jitter only in the existing canary, API, and topology suite entry points, restoring the previous property afterward. Production scheduling and concurrency assertions remain unchanged.

Workflow/cache changes and jitter changes are separated into two commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test consistency by temporarily disabling job timing variability during API, canary, and topology test runs.
  - Fuzz seed coverage is now included through the standard recursive test process.

- **Chores**
  - Updated continuous integration caching to reuse Go build artifacts and modules more efficiently.
  - Added clearer visibility into the caches used during test workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->